### PR TITLE
Trailing slashes in included makefiles break build under OS X

### DIFF
--- a/libuavcan/include.mk
+++ b/libuavcan/include.mk
@@ -9,7 +9,7 @@ UAVCAN_DIR := $(LIBUAVCAN_DIR)/../
 #
 # Library sources
 #
-LIBUAVCAN_SRC := $(shell find $(LIBUAVCAN_DIR)/src/ -type f -name '*.cpp')
+LIBUAVCAN_SRC := $(shell find $(LIBUAVCAN_DIR)/src -type f -name '*.cpp')
 
 LIBUAVCAN_INC := $(LIBUAVCAN_DIR)/include
 

--- a/libuavcan_drivers/stm32/driver/include.mk
+++ b/libuavcan_drivers/stm32/driver/include.mk
@@ -4,6 +4,6 @@
 
 LIBUAVCAN_STM32_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-LIBUAVCAN_STM32_SRC := $(shell find $(LIBUAVCAN_STM32_DIR)/src/ -type f -name '*.cpp')
+LIBUAVCAN_STM32_SRC := $(shell find $(LIBUAVCAN_STM32_DIR)/src -type f -name '*.cpp')
 
 LIBUAVCAN_STM32_INC := $(LIBUAVCAN_STM32_DIR)/include/


### PR DESCRIPTION
Hi Pavel
I had trouble building the px4esc firmware under OS X. Looks like the trailing slashes for source folders in the included uavcan makefiles were the issue. The build should still work under Linux.
Cheers
Ada
