### PR TITLE
Allowing > 255 byte static allocator blocks

### DIFF
--- a/libcyphal/include/libcyphal/platform/memory.hpp
+++ b/libcyphal/include/libcyphal/platform/memory.hpp
@@ -31,14 +31,14 @@ namespace memory
  * @tparam  NumBlocksParam  The number of blocks to allocate in the pool. Unlike an arena allocator,
  *                          this allocator does not guarantee a continuous block of memory and each
  *                          memory block can located anywhere on the system. It is highly recommended
- *                          that all memory blocks have the same access permsissions and performance.
+ *                          that all memory blocks have the same access permissions and performance.
  * @tparam  BlockSizeParam  The size in bytes of each block. Note that all blocks will use this size
  *                          such that the amount of memory allocated for the pool will be at least
  *                          NumBlocksParam x BlockSizeParam bytes. Implementations may choose to
  *                          allocate additional memory per-block to detect buffer overrun and illegal
  *                          deallocation.
  */
-template <std::size_t NumBlocksParam, std::uint8_t BlockSizeParam>
+template <std::size_t NumBlocksParam, std::size_t BlockSizeParam>
 class LIBCYPHAL_EXPORT StaticMemoryPool final
 {
     /**
@@ -112,9 +112,9 @@ class LIBCYPHAL_EXPORT StaticMemoryPool final
     ~StaticMemoryPool() = default;
 
 public:
-    StaticMemoryPool(const StaticMemoryPool&)             = delete;
-    StaticMemoryPool(const StaticMemoryPool&&)            = delete;
-    StaticMemoryPool& operator=(const StaticMemoryPool&)  = delete;
+    StaticMemoryPool(const StaticMemoryPool&)  = delete;
+    StaticMemoryPool(const StaticMemoryPool&&) = delete;
+    StaticMemoryPool& operator=(const StaticMemoryPool&) = delete;
     StaticMemoryPool& operator=(const StaticMemoryPool&&) = delete;
 
 private:
@@ -122,7 +122,7 @@ private:
     // | ALLOCATORS
     // |    A list of allocators that can use this memory pool.
     // +------------------------------------------------------------------+
-    template <std::size_t, std::uint8_t, typename, typename>
+    template <std::size_t, std::size_t, typename, typename>
     friend class PoolAllocator;
 
     /**
@@ -197,7 +197,7 @@ private:
  *                              5. sizeof(T) shall be >= BlockSizeParam.
  */
 template <std::size_t  NumBlocksParam,
-          std::uint8_t BlockSizeParam,
+          std::size_t  BlockSizeParam,
           typename T              = std::uint8_t,
           typename MemoryPoolType = StaticMemoryPool<NumBlocksParam, BlockSizeParam>>
 class LIBCYPHAL_EXPORT PoolAllocator
@@ -207,26 +207,22 @@ class LIBCYPHAL_EXPORT PoolAllocator
 public:
     explicit PoolAllocator() noexcept
         : pool_(MemoryPoolType::getReference())
-    {
-    }
+    {}
 
     explicit PoolAllocator(const PoolAllocator& rhs) noexcept
         : pool_(rhs.pool_)
-    {
-    }
+    {}
 
     explicit PoolAllocator(const PoolAllocator&& rhs) noexcept
         : pool_(rhs.pool_)
-    {
-    }
+    {}
 
     ~PoolAllocator() = default;
 
     template <typename T1>
     PoolAllocator(const PoolAllocator<NumBlocksParam, BlockSizeParam, T1, MemoryPoolType>&) noexcept
         : pool_(MemoryPoolType::getReference())
-    {
-    }
+    {}
 
     static_assert(sizeof(typename std::conditional<std::is_same<void, T>::value, std::uint8_t, T>::type) <=
                       BlockSizeParam,

--- a/libcyphal_validation_suite/include/lvs/platform/memory.hpp
+++ b/libcyphal_validation_suite/include/lvs/platform/memory.hpp
@@ -61,7 +61,8 @@ namespace memory
  */
 template <typename T>
 class PoolAllocatorTest : public ::testing::Test
-{};
+{
+};
 
 TYPED_TEST_SUITE_P(PoolAllocatorTest);
 
@@ -201,7 +202,8 @@ constexpr static const std::size_t MinimumBlockSize = 10;
  */
 template <typename T>
 class PoolAllocatorVectorTest : public ::testing::Test
-{};
+{
+};
 
 TYPED_TEST_SUITE_P(PoolAllocatorVectorTest);
 
@@ -271,7 +273,8 @@ using AllocatorPtrType = std::pair<const int, int>;
 /**
  * Required block size for the TypeParam to be valid for these tests.
  */
-constexpr static const std::size_t MinimumBlockSize = sizeof(AllocatorPtrType) + 64;
+constexpr static const std::size_t MinimumBlockSize =
+    sizeof(AllocatorPtrType) * alignof(AllocatorPtrType) * MinimumBlockCount;
 }  // namespace PoolAllocatorUnorderedMapTestRequirements
 
 /**
@@ -283,7 +286,8 @@ constexpr static const std::size_t MinimumBlockSize = sizeof(AllocatorPtrType) +
  */
 template <typename T>
 class PoolAllocatorUnorderedMapTest : public ::testing::Test
-{};
+{
+};
 
 TYPED_TEST_SUITE_P(PoolAllocatorUnorderedMapTest);
 

--- a/test/native/test_platform_memory_poolallocator.cpp
+++ b/test/native/test_platform_memory_poolallocator.cpp
@@ -20,7 +20,8 @@ typedef ::testing::Types<libcyphal::platform::memory::PoolAllocator<1, 1>,
 
 // The trailing comma is required. See https://github.com/google/googletest/issues/1419
 INSTANTIATE_TYPED_TEST_SUITE_P(Generic, PoolAllocatorTest, MyTypes, );
-
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(PoolAllocatorUnorderedMapTest);
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(PoolAllocatorVectorTest);
 }  // namespace memory
 }  // namespace platform
 }  // namespace lvs

--- a/test/native/test_platform_memory_poolallocator_unordered_map.cpp
+++ b/test/native/test_platform_memory_poolallocator_unordered_map.cpp
@@ -21,7 +21,8 @@ typedef ::testing::Types<
 
 // The trailing comma is required. See https://github.com/google/googletest/issues/1419
 INSTANTIATE_TYPED_TEST_SUITE_P(Generic, PoolAllocatorUnorderedMapTest, MyTypes, );
-
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(PoolAllocatorTest);
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(PoolAllocatorVectorTest);
 }  // namespace memory
 }  // namespace platform
 }  // namespace lvs

--- a/test/native/test_platform_memory_poolallocator_vector.cpp
+++ b/test/native/test_platform_memory_poolallocator_vector.cpp
@@ -21,6 +21,8 @@ typedef ::testing::Types<
 
 // The trailing comma is required. See https://github.com/google/googletest/issues/1419
 INSTANTIATE_TYPED_TEST_SUITE_P(Generic, PoolAllocatorVectorTest, MyTypes, );
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(PoolAllocatorTest);
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(PoolAllocatorUnorderedMapTest);
 
 }  // namespace memory
 }  // namespace platform

--- a/test/native/test_time_duration.cpp
+++ b/test/native/test_time_duration.cpp
@@ -46,5 +46,7 @@ namespace lvs
 typedef ::testing::Types<libcyphal::duration::Monotonic> MyDurationTypes;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Time, DurationTest, MyDurationTypes, );
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DurationOrTimeTest);
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TimeTest);
 
 }  // namespace lvs

--- a/test/native/test_time_duration_and_time.cpp
+++ b/test/native/test_time_duration_and_time.cpp
@@ -46,5 +46,7 @@ typedef ::testing::Types<libcyphal::duration::Monotonic, libcyphal::time::Monoto
 
 // The trailing comma is required. See https://github.com/google/googletest/issues/1419
 INSTANTIATE_TYPED_TEST_SUITE_P(Time, DurationOrTimeTest, MyDurationAndTimeTypes, );
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DurationTest);
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TimeTest);
 
 }  // namespace lvs

--- a/test/native/test_time_time.cpp
+++ b/test/native/test_time_time.cpp
@@ -46,5 +46,7 @@ namespace lvs
 typedef ::testing::Types<libcyphal::time::Monotonic> MyTimeTypes;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Time, TimeTest, MyTimeTypes, );
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DurationOrTimeTest);
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DurationTest);
 
 }  // namespace lvs

--- a/test/native/tests.cmake
+++ b/test/native/tests.cmake
@@ -82,6 +82,7 @@ set(ALL_TEST_COVERAGE "")
 
 foreach(NATIVE_TEST ${NATIVE_TESTS})
     get_filename_component(NATIVE_TEST_NAME ${NATIVE_TEST} NAME_WE)
+    message(STATUS "Defining googletest binary ${NATIVE_TEST_NAME} for source file ${NATIVE_TEST}")
     define_native_unit_test(${NATIVE_TEST_NAME} ${NATIVE_TEST} ${LIBCYPHAL_NATIVE_TEST_BINARY_DIR})
     define_native_test_run(${NATIVE_TEST_NAME} ${LIBCYPHAL_NATIVE_TEST_BINARY_DIR})
     define_native_test_run_with_lcov(${NATIVE_TEST_NAME} ${LIBCYPHAL_NATIVE_TEST_BINARY_DIR})


### PR DESCRIPTION
This also fixes the unit tests