### PR TITLE
Trivial suggestions for the Transport layer redesign PR

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -28,7 +28,6 @@ BraceWrapping:
     AfterStruct: true
     AfterClass: true
     AfterControlStatement: true
-    AfterEnum: true
     AfterFunction: true
     AfterUnion: true
     AfterNamespace: true
@@ -50,6 +49,7 @@ DisableFormat:   false
 FixNamespaceComments: true
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 IncludeBlocks: Preserve
+InsertNewlineAtEOF: true
 IndentCaseLabels: false
 IndentPPDirectives: AfterHash
 IndentWidth:     4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-
+cmake-build*/
 clang-format-diff-warnings
 build
 external/**/*
 .DS_Store
+
+.idea/
+!/.idea/dictionaries
+!/.idea/dictionaries/*

--- a/libcyphal/include/libcyphal/libcyphal.hpp
+++ b/libcyphal/include/libcyphal/libcyphal.hpp
@@ -289,8 +289,7 @@ struct MutableStatus final
     }
 };
 
-using NodeID                     = std::uint16_t;
-constexpr NodeID anonymousNodeID = std::numeric_limits<NodeID>::max();
+using NodeID                     = std::uint16_t;  ///< Anonymity is represented by an empty optional<NodeID>.
 using PortID                     = std::uint16_t;
 using TransferID                 = std::uint64_t;
 

--- a/libcyphal/include/libcyphal/transport/transport.hpp
+++ b/libcyphal/include/libcyphal/transport/transport.hpp
@@ -76,7 +76,7 @@ public:
     /// See ProtocolParameters.
     ///
     /// @return ProtocolParameters object if the transport is initialized, otherwise ResultCode::UninitializedError.
-    virtual ProtocolParameters protocolParameters() const noexcept = 0;
+    virtual ProtocolParameters getProtocolParameters() const noexcept = 0;
 
     /// The node-ID is set once during initialization of the transport,
     /// either explicitly (e.g., CAN) or by deriving the node-ID value from the configuration
@@ -88,7 +88,7 @@ public:
     /// plug-and-play node-ID allocation (for example, a CAN transport may disable automatic retransmission).
     ///
     /// @return Optional integer representing the local node-ID.
-    virtual janky::optional<NodeID> localNodeId() const = 0;
+    virtual janky::optional<NodeID> getLocalNodeId() const = 0;
 
     /// Closes all active sessions, underlying media instances, and other resources related to this transport instance.
     ///

--- a/libcyphal/include/libcyphal/transport/transport.hpp
+++ b/libcyphal/include/libcyphal/transport/transport.hpp
@@ -28,7 +28,7 @@ namespace transport
 /// This is not a hard guarantee, however.
 /// For example, a redundant transport aggregator may return a different set of parameters after
 /// the set of aggregated transports is changed (i.e., a transport is added or removed).
-struct ProtocolParameters
+struct ProtocolParameters final
 {
     /// The cardinality of the set of distinct transfer-ID values; i.e., the overflow period.
     /// All high-overhead transports (UDP, Serial, etc.) use a sufficiently large value that will never overflow
@@ -36,11 +36,11 @@ struct ProtocolParameters
     /// The background and motivation are explained at
     /// https://forum.opencyphal.org/t/alternative-transport-protocols/324.
     /// Example: 32 for CAN, (2**64) for UDP.
-    std::size_t transfer_id_modulo;
+    std::uint64_t transfer_id_modulo;
 
     /// How many nodes can the transport accommodate in a given network.
-    /// Example: 128 for CAN, 65534 for UDP.
-    std::size_t max_nodes;
+    /// Example: 128 for CAN, 65535 for UDP (0xFFFF is reserved).
+    std::uint32_t max_nodes;
 
     /// The largest maximum number of payload bytes in a single-frame transfer for the group of network interfaces
     /// used by the transport. This number can change on systems where the value is configurable.

--- a/libcyphal/include/libcyphal/transport/udp/ard.h
+++ b/libcyphal/include/libcyphal/transport/udp/ard.h
@@ -32,6 +32,8 @@ static_assert(UDPARD_CYPHAL_HEADER_VERSION == 1,
 
 constexpr NodeID AnonymousNodeID = UDPARD_NODE_ID_UNSET;
 
+constexpr std::size_t DefaultMTU = 1408;  // TODO use UDPARD_MTU_DEFAULT
+
 constexpr ResultCode fromUdpardResult(std::int32_t result)
 {
     if (result >= 0)

--- a/libcyphal/include/libcyphal/transport/udp/ard.h
+++ b/libcyphal/include/libcyphal/transport/udp/ard.h
@@ -30,6 +30,8 @@ static_assert(UDPARD_CYPHAL_HEADER_VERSION == 1,
               "We expected udpard.h to be UDPARD_CYPHAL_HEADER_VERSION==1. Please update this header to handle other "
               "versions and then change this static assert.");
 
+constexpr NodeID AnonymousNodeID = UDPARD_NODE_ID_UNSET;
+
 constexpr ResultCode fromUdpardResult(std::int32_t result)
 {
     if (result >= 0)

--- a/libcyphal/include/libcyphal/transport/udp/session/output.hpp
+++ b/libcyphal/include/libcyphal/transport/udp/session/output.hpp
@@ -161,7 +161,7 @@ public:
         UdpardTransferMetadata metadata{toUdpardPriority(priority),
                                         toUdpTransferKind(specifier_),
                                         specifier_.getDataSpecifier().getId(),
-                                        specifier_.getRemoteNodeId().value_or(anonymousNodeID),
+                                        specifier_.getRemoteNodeId().value_or(AnonymousNodeID),
                                         0};
         for (RedundantNetworkTxInterface& interface : interfaces_)
         {

--- a/libcyphal/include/libcyphal/transport/udp/transport.hpp
+++ b/libcyphal/include/libcyphal/transport/udp/transport.hpp
@@ -1,5 +1,5 @@
 /// @file
-/// Cyphal Transport Interface implementation used to communicate over a UDP bus
+/// Cyphal Transport Interface implementation used to communicate over a UDP/IP network.
 ///
 /// @copyright
 /// Copyright (C) OpenCyphal Development Team  <opencyphal.org>

--- a/libcyphal/include/libcyphal/transport/udp/transport.hpp
+++ b/libcyphal/include/libcyphal/transport/udp/transport.hpp
@@ -50,16 +50,6 @@ struct TransportMemoryResources
 class Transport final : public ITransport, public IRunnable
 {
 public:
-    ///
-    /// The minimum is based on the IPv6 specification, which guarantees that the path MTU is at least 1280 bytes large.
-    /// This value is also acceptable for virtually all IPv4 local or real-time networks.
-    /// Lower MTU values shall not be used because they may lead to multi-frame transfer fragmentation where this is
-    /// not expected by the designer, possibly violating the real-time constraints.
-    ///
-    /// A conventional Ethernet jumbo frame can carry up to 9 KiB (9216 bytes).
-    /// These are the application-level MTU values, so we take overheads into account.
-    static constexpr std::uint32_t ValidMTURange[2] = {1200, 9000};
-
     /// @brief  Per [Table 4.5] of the Cyphal specification.
     static constexpr std::size_t MaxNodeIdValue = 65534;
 
@@ -94,7 +84,7 @@ public:
     Transport(network::IContext&         network_context,
               janky::optional<NodeID>    local_node_id,
               TransportMemoryResources&& memory_resources,
-              std::uint32_t              mtu_bytes = ValidMTURange[0])
+              std::uint32_t              mtu_bytes = DefaultMTU)
         : network_context_{network_context}
         , local_node_id_(local_node_id)
         , mtu_bytes_{mtu_bytes}
@@ -113,7 +103,7 @@ public:
         (void) std::move(memory_resources);
     }
 
-    ~Transport() noexcept                  = default;
+    ~Transport() noexcept final            = default;
     Transport(const Transport&)            = delete;
     Transport(Transport&&)                 = delete;
     Transport& operator=(const Transport&) = delete;
@@ -272,7 +262,7 @@ public:
                 return Status{ip_socket_perhaps.error(), 0x55};
             }
             network::SocketPointer<network::ip::Socket>&& ip_socket = std::move(ip_socket_perhaps.value());
-            const Status                                  r = ip_socket->connect(multicast_address, network::ip::udp::CyphalPort);
+            const Status r = ip_socket->connect(multicast_address, network::ip::udp::CyphalPort);
             if (r != ResultCode::Success)
             {
                 return Status{r.result, 0x56};

--- a/libcyphal/include/libcyphal/transport/udp/transport.hpp
+++ b/libcyphal/include/libcyphal/transport/udp/transport.hpp
@@ -41,7 +41,8 @@ struct TransportMemoryResources
     cetl::pf17::pmr::memory_resource* input_session_memory;
     cetl::pf17::pmr::memory_resource* output_session_memory;
     cetl::pf17::pmr::memory_resource* tx_queue_memory;
-    // TODO: update 'ards so this can be two separate memory resources.
+    // TODO [Scott]: update 'ards so this can be two separate memory resources.
+    //      [Pavel]: This is done in the main2 branch, see struct UdpardRxMemoryResources.
     cetl::pf17::pmr::memory_resource* rx_payload_buffer_and_session_memory;
 };
 
@@ -100,8 +101,8 @@ public:
         , input_registry_allocator_{memory_resources.input_session_memory}
         , output_registry_allocator_{memory_resources.output_session_memory}
         , closed_{false}
-        , tx_context_{local_node_id.value_or(anonymousNodeID), memory_resources.tx_queue_memory}
-        , rx_context_{local_node_id.value_or(anonymousNodeID), memory_resources.rx_payload_buffer_and_session_memory}
+        , tx_context_{local_node_id.value_or(AnonymousNodeID), memory_resources.tx_queue_memory}
+        , rx_context_{local_node_id.value_or(AnonymousNodeID), memory_resources.rx_payload_buffer_and_session_memory}
         , interfaces_{}
         , input_registry_{input_registry_allocator_}
         , output_registry_{output_registry_allocator_}
@@ -155,12 +156,12 @@ public:
         return ResultCode::Success;
     }
 
-    ProtocolParameters protocolParameters() const noexcept override
+    ProtocolParameters getProtocolParameters() const noexcept override
     {
         return ProtocolParameters{std::numeric_limits<TransferID>::max(), MaxNodeIdValue, mtu_bytes_};
     }
 
-    janky::optional<NodeID> localNodeId() const override
+    janky::optional<NodeID> getLocalNodeId() const override
     {
         return local_node_id_;
     }


### PR DESCRIPTION
This is a follow-up to https://github.com/OpenCyphal-Garage/libcyphal/pull/330#pullrequestreview-1563979276

I removed the top-level anonymous node-ID constant of 0xFFFF because it is not as expressive as an empty `std::optional<NodeID>`.