### PR TITLE
Issue 336: Declare libcyphal transport interfaces

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,9 +98,9 @@ jobs:
       if: ${{ runner.debug == '1' }}
       run: ls -lAhR build/
     - name: upload-artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.build_flavor }}-${{ matrix.exceptions }}-${{ matrix.std }}-${{ matrix.toolchain }}
+        name: ${{ matrix.build_flavor }}-${{ matrix.std }}-${{ matrix.toolchain }}
         path: |
           build/compile_commands.json
           build/*/**/coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,9 +61,13 @@ jobs:
     needs: [warmup]
     strategy:
       matrix:
-        flavor: [Release, Debug]
+        build_flavor: [Release, Debug]
         std: [14, 17, 20]
         toolchain: [gcc, clang]
+        include:
+          - build_flavor: Coverage
+            std: 14
+            toolchain: gcc
     steps:
     - uses: actions/checkout@v4
       if: ${{ github.event_name != 'act' }}
@@ -79,15 +83,31 @@ jobs:
     - name: get nunavut
       run: >
         pip install nunavut
-    - name: release
+    - name: run tests
+      env:
+        GTEST_COLOR: yes
       run: >
         ./build-tools/bin/verify.py
         --verbose
         --asserts
         --cpp-standard ${{ matrix.std }}
-        --build-flavor ${{ matrix.flavor }}
+        --build-flavor ${{ matrix.build_flavor }}
         --toolchain ${{ matrix.toolchain }}
-        clean-release
+        test
+    - name: debug output
+      if: ${{ runner.debug == '1' }}
+      run: ls -lAhR build/
+    - name: upload-artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.build_flavor }}-${{ matrix.exceptions }}-${{ matrix.std }}-${{ matrix.toolchain }}
+        path: |
+          build/compile_commands.json
+          build/*/**/coverage.xml
+          build/*/**/*-sonarqube.xml
+          build/*/**/gcovr_html/*.*
+        if-no-files-found: error
+
   docs:
     if: >
       contains(github.event.head_commit.message, '#docs') ||

--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -115,3 +115,9 @@ add_custom_target(
 set_directory_properties(PROPERTIES
     IN_BUILD_TESTS "${ALL_EXAMPLE_RUNS}"
 )
+
+if (CMAKE_BUILD_TYPE STREQUAL "Coverage")
+    enable_coverage_report(COVERAGE_REPORT_FORMATS sonarqube html
+                           ROOT_DIRECTORY ${LIBCYPHAL_ROOT}
+    )
+endif()

--- a/include/libcyphal/runnable.hpp
+++ b/include/libcyphal/runnable.hpp
@@ -19,9 +19,9 @@ public:
     virtual void run(const TimePoint now) = 0;
 
 protected:
-    IRunnable() = default;
+    IRunnable()                 = default;
     IRunnable(const IRunnable&) = default;
-    IRunnable(IRunnable&&) = default;
+    IRunnable(IRunnable&&)      = default;
 
     IRunnable& operator=(const IRunnable&) = default;
     IRunnable& operator=(IRunnable&&)      = default;

--- a/include/libcyphal/runnable.hpp
+++ b/include/libcyphal/runnable.hpp
@@ -14,10 +14,17 @@ namespace libcyphal
 class IRunnable
 {
 public:
+    virtual ~IRunnable() = default;
+
     virtual void run(const TimePoint now) = 0;
 
 protected:
-    virtual ~IRunnable() = default;
+    IRunnable() = default;
+    IRunnable(const IRunnable&) = default;
+    IRunnable(IRunnable&&) = default;
+
+    IRunnable& operator=(const IRunnable&) = default;
+    IRunnable& operator=(IRunnable&&)      = default;
 };
 
 }  // namespace libcyphal

--- a/include/libcyphal/transport/defines.hpp
+++ b/include/libcyphal/transport/defines.hpp
@@ -6,6 +6,8 @@
 #ifndef LIBCYPHAL_TRANSPORT_DEFINES_HPP_INCLUDED
 #define LIBCYPHAL_TRANSPORT_DEFINES_HPP_INCLUDED
 
+#include "dynamic_buffer.hpp"
+
 namespace libcyphal
 {
 namespace transport
@@ -68,9 +70,6 @@ struct ServiceTransferMetadata final : TransferMetadata
 // TODO: Maybe have `cetl::byte` polyfill for C++20
 using PayloadFragments = cetl::span<cetl::span<uint8_t>>;
 
-struct DynamicBuffer final
-{};
-
 struct MessageRxTransfer final
 {
     TransferMetadata       metadata;
@@ -80,7 +79,7 @@ struct MessageRxTransfer final
     MessageRxTransfer(TransferMetadata _metadata, cetl::optional<NodeId> _publisher_node_id, DynamicBuffer _payload)
         : metadata{_metadata}
         , publisher_node_id{_publisher_node_id}
-        , payload{_payload}
+        , payload{std::move(_payload)}
     {
     }
 };
@@ -92,7 +91,7 @@ struct ServiceRxTransfer final
 
     ServiceRxTransfer(ServiceTransferMetadata _metadata, DynamicBuffer _payload)
         : metadata{_metadata}
-        , payload{_payload}
+        , payload{std::move(_payload)}
     {
     }
 };

--- a/include/libcyphal/transport/defines.hpp
+++ b/include/libcyphal/transport/defines.hpp
@@ -28,11 +28,74 @@ using TransferId = std::uint64_t;
 
 struct ProtocolParams final
 {
-    std::uint64_t transfer_id_modulo;
-    std::size_t   mtu_bytes;
-    NodeId        max_nodes;
+    TransferId  transfer_id_modulo;
+    std::size_t mtu_bytes;
+    NodeId      max_nodes;
 
-};  // ProtocolParams
+    ProtocolParams(TransferId _transfer_id_modulo, std::size_t _mtu_bytes, NodeId _max_nodes)
+        : transfer_id_modulo{_transfer_id_modulo}
+        , mtu_bytes{_mtu_bytes}
+        , max_nodes{_max_nodes}
+    {
+    }
+};
+
+struct TransferMetadata
+{
+    TransferId transfer_id;
+    TimePoint  timestamp;
+    Priority   priority;
+
+    TransferMetadata(TransferId _transfer_id, TimePoint _timestamp, Priority _priority)
+        : transfer_id{_transfer_id}
+        , timestamp{_timestamp}
+        , priority{_priority}
+    {
+    }
+};
+
+struct ServiceTransferMetadata final : TransferMetadata
+{
+    NodeId remote_node_id;
+
+    ServiceTransferMetadata(TransferId _transfer_id, TimePoint _timestamp, Priority _priority, NodeId _remote_node_id)
+        : TransferMetadata{_transfer_id, _timestamp, _priority}
+        , remote_node_id{_remote_node_id}
+    {
+    }
+};
+
+// TODO: Maybe have `cetl::byte` polyfill for C++20
+using PayloadFragments = cetl::span<cetl::span<uint8_t>>;
+
+struct DynamicBuffer final
+{};
+
+struct MessageRxTransfer final
+{
+    TransferMetadata       metadata;
+    cetl::optional<NodeId> publisher_node_id;
+    DynamicBuffer          payload;
+
+    MessageRxTransfer(TransferMetadata _metadata, cetl::optional<NodeId> _publisher_node_id, DynamicBuffer _payload)
+        : metadata{_metadata}
+        , publisher_node_id{_publisher_node_id}
+        , payload{_payload}
+    {
+    }
+};
+
+struct ServiceRxTransfer final
+{
+    ServiceTransferMetadata metadata;
+    DynamicBuffer           payload;
+
+    ServiceRxTransfer(ServiceTransferMetadata _metadata, DynamicBuffer _payload)
+        : metadata{_metadata}
+        , payload{_payload}
+    {
+    }
+};
 
 }  // namespace transport
 }  // namespace libcyphal

--- a/include/libcyphal/transport/defines.hpp
+++ b/include/libcyphal/transport/defines.hpp
@@ -28,9 +28,9 @@ using TransferId = std::uint64_t;
 
 struct ProtocolParams final
 {
-    NodeId        max_nodes;
-    std::size_t   mtu_bytes;
     std::uint64_t transfer_id_modulo;
+    std::size_t   mtu_bytes;
+    NodeId        max_nodes;
 
 };  // ProtocolParams
 

--- a/include/libcyphal/transport/dynamic_buffer.hpp
+++ b/include/libcyphal/transport/dynamic_buffer.hpp
@@ -86,6 +86,15 @@ public:
         interface_ = nullptr;
     }
 
+    /// @brief Gets the number of bytes stored in the buffer (possibly scattered, but this is hidden from the user).
+    ///
+    /// @return Returns zero if the buffer is moved away.
+    ///
+    CETL_NODISCARD std::size_t size() const
+    {
+        return interface_ ? interface_->size() : 0;
+    }
+
     /// @brief Copies a fragment of the specified size at the specified offset out of the buffer.
     ///
     /// The request is truncated to prevent out-of-range memory access.
@@ -97,14 +106,6 @@ public:
                                     const std::size_t length_bytes) const
     {
         return interface_ ? interface_->copy(offset_bytes, destination, length_bytes) : 0;
-    }
-
-    /// @brief Gets the number of bytes stored in the buffer (possibly scattered, but this is hidden from the user).
-    /// @return Returns zero if the buffer is moved away.
-    ///
-    CETL_NODISCARD std::size_t size() const
-    {
-        return interface_ ? interface_->size() : 0;
     }
 
 private:

--- a/include/libcyphal/transport/dynamic_buffer.hpp
+++ b/include/libcyphal/transport/dynamic_buffer.hpp
@@ -1,0 +1,119 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef LIBCYPHAL_TRANSPORT_DYNAMIC_BUFFER_HPP_INCLUDED
+#define LIBCYPHAL_TRANSPORT_DYNAMIC_BUFFER_HPP_INCLUDED
+
+#include <cetl/any.hpp>
+
+#include <cstdint>
+
+namespace libcyphal
+{
+namespace transport
+{
+
+/// The buffer is movable but not copyable because copying the contents of a buffer is considered wasteful.
+/// The buffer behaves as if it's empty if the underlying implementation is moved away.
+///
+class DynamicBuffer final
+{
+    // 91C1B109-F90E-45BE-95CF-6ED02AC3FFAA
+    using InterfaceTypeIdType = cetl::
+        type_id_type<0x91, 0xC1, 0xB1, 0x09, 0xF9, 0x0E, 0x45, 0xBE, 0x95, 0xCF, 0x6E, 0xD0, 0x2A, 0xC3, 0xFF, 0xAA>;
+
+public:
+    static constexpr std::size_t ImplementationFootprint = sizeof(void*) * 8;
+
+    class Interface : public cetl::rtti_helper<InterfaceTypeIdType>
+    {
+    public:
+        Interface(const Interface&)            = delete;
+        Interface& operator=(const Interface&) = delete;
+
+        CETL_NODISCARD virtual std::size_t size() const                               = 0;
+        CETL_NODISCARD virtual std::size_t copy(const std::size_t offset_bytes,
+                                                void* const       destination,
+                                                const std::size_t length_bytes) const = 0;
+
+    protected:
+        Interface()                                = default;
+        Interface(Interface&&) noexcept            = default;
+        Interface& operator=(Interface&&) noexcept = default;
+
+    };  // Interface
+
+    DynamicBuffer()                           = default;
+    DynamicBuffer(const DynamicBuffer& other) = delete;
+    DynamicBuffer(DynamicBuffer&& other) noexcept
+    {
+        storage_ = std::move(other.storage_);
+
+        other.interface_ = nullptr;
+        interface_       = cetl::any_cast<Interface>(&storage_);
+    }
+
+    /// @brief Accepts a Lizard-specific implementation of `Interface` and moves it into the internal storage.
+    ///
+    template <typename T, typename = std::enable_if_t<std::is_base_of<Interface, T>::value>>
+    explicit DynamicBuffer(T&& source) noexcept
+        : storage_(std::forward<T>(source))
+        , interface_{cetl::any_cast<Interface>(&storage_)}
+    {
+    }
+
+    ~DynamicBuffer()
+    {
+        reset();
+    }
+
+    DynamicBuffer& operator=(const DynamicBuffer& other) = delete;
+    DynamicBuffer& operator=(DynamicBuffer&& other) noexcept
+    {
+        storage_ = std::move(other.storage_);
+
+        other.interface_ = nullptr;
+        interface_       = cetl::any_cast<Interface>(&storage_);
+
+        return *this;
+    }
+
+    void reset() noexcept
+    {
+        storage_.reset();
+        interface_ = nullptr;
+    }
+
+    /// @brief Copies a fragment of the specified size at the specified offset out of the buffer.
+    ///
+    /// The request is truncated to prevent out-of-range memory access.
+    /// Returns the number of bytes copied.
+    /// Does nothing and returns zero if the instance has been moved away.
+    ///
+    CETL_NODISCARD std::size_t copy(const std::size_t offset_bytes,
+                                    void* const       destination,
+                                    const std::size_t length_bytes) const
+    {
+        return interface_ ? interface_->copy(offset_bytes, destination, length_bytes) : 0;
+    }
+
+    /// @brief Gets the number of bytes stored in the buffer (possibly scattered, but this is hidden from the user).
+    /// @return Returns zero if the buffer is moved away.
+    ///
+    CETL_NODISCARD std::size_t size() const
+    {
+        return interface_ ? interface_->size() : 0;
+    }
+
+private:
+    cetl::any<ImplementationFootprint, false, true> storage_;
+    const Interface*                                interface_ = nullptr;
+
+};  // DynamicBuffer
+
+}  // namespace transport
+}  // namespace libcyphal
+
+#endif  // LIBCYPHAL_TRANSPORT_DYNAMIC_BUFFER_HPP_INCLUDED

--- a/include/libcyphal/transport/errors.hpp
+++ b/include/libcyphal/transport/errors.hpp
@@ -1,0 +1,43 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef LIBCYPHAL_TRANSPORT_ERRORS_HPP_INCLUDED
+#define LIBCYPHAL_TRANSPORT_ERRORS_HPP_INCLUDED
+
+#include "libcyphal/types.hpp"
+
+namespace libcyphal
+{
+namespace transport
+{
+
+struct StateError
+{};
+
+struct AnonymousError
+{};
+
+struct ArgumentError
+{};
+
+struct MemoryError
+{};
+
+struct CapacityError
+{};
+
+struct PlatformError
+{
+    std::uint32_t code;
+};
+
+/// @brief Defines any possible error at Cyphal transport layer.
+///
+using AnyError = cetl::variant<StateError, AnonymousError, ArgumentError, MemoryError, CapacityError, PlatformError>;
+
+}  // namespace transport
+}  // namespace libcyphal
+
+#endif  // LIBCYPHAL_TRANSPORT_ERRORS_HPP_INCLUDED

--- a/include/libcyphal/transport/session/msg_sessions.hpp
+++ b/include/libcyphal/transport/session/msg_sessions.hpp
@@ -29,13 +29,16 @@ struct MessageTxParams final
 class IMessageRxSession : public IRxSession
 {
 public:
-    CETL_NODISCARD virtual MessageRxParams getParams() const noexcept = 0;
+    CETL_NODISCARD virtual MessageRxParams   getParams() const noexcept = 0;
+    CETL_NODISCARD virtual MessageRxTransfer receive()                  = 0;
 };
 
 class IMessageTxSession : public IRunnable
 {
 public:
-    CETL_NODISCARD virtual MessageTxParams getParams() const noexcept = 0;
+    CETL_NODISCARD virtual MessageTxParams          getParams() const noexcept                     = 0;
+    CETL_NODISCARD virtual Expected<void, AnyError> send(const TransferMetadata metadata,
+                                                         const PayloadFragments payload_fragments) = 0;
 };
 
 }  // namespace session

--- a/include/libcyphal/transport/session/svc_sessions.hpp
+++ b/include/libcyphal/transport/session/svc_sessions.hpp
@@ -39,7 +39,13 @@ struct ResponseTxParams final
     PortId service_id;
 };
 
-class IRequestRxSession : public IRxSession
+class ISvcRxSession : public IRxSession
+{
+public:
+    CETL_NODISCARD virtual ServiceRxTransfer receive() = 0;
+};
+
+class IRequestRxSession : public ISvcRxSession
 {
 public:
     CETL_NODISCARD virtual RequestRxParams getParams() const noexcept = 0;
@@ -48,10 +54,12 @@ public:
 class IRequestTxSession : public ISession
 {
 public:
-    CETL_NODISCARD virtual RequestTxParams getParams() const noexcept = 0;
+    CETL_NODISCARD virtual RequestTxParams          getParams() const noexcept                     = 0;
+    CETL_NODISCARD virtual Expected<void, AnyError> send(const TransferMetadata metadata,
+                                                         const PayloadFragments payload_fragments) = 0;
 };
 
-class IResponseRxSession : public IRxSession
+class IResponseRxSession : public ISvcRxSession
 {
 public:
     CETL_NODISCARD virtual ResponseRxParams getParams() const noexcept = 0;
@@ -60,7 +68,9 @@ public:
 class IResponseTxSession : public ISession
 {
 public:
-    CETL_NODISCARD virtual ResponseTxParams getParams() const noexcept = 0;
+    CETL_NODISCARD virtual ResponseTxParams         getParams() const noexcept                     = 0;
+    CETL_NODISCARD virtual Expected<void, AnyError> send(const ServiceTransferMetadata metadata,
+                                                         const PayloadFragments        payload_fragments) = 0;
 };
 
 }  // namespace session

--- a/include/libcyphal/transport/transport.hpp
+++ b/include/libcyphal/transport/transport.hpp
@@ -6,6 +6,7 @@
 #ifndef LIBCYPHAL_TRANSPORT_TRANSPORT_HPP_INCLUDED
 #define LIBCYPHAL_TRANSPORT_TRANSPORT_HPP_INCLUDED
 
+#include "errors.hpp"
 #include "session/msg_sessions.hpp"
 #include "session/svc_sessions.hpp"
 
@@ -19,6 +20,18 @@ class ITransport : public IRunnable
 public:
     CETL_NODISCARD virtual cetl::optional<NodeId> getLocalNodeId() const noexcept    = 0;
     CETL_NODISCARD virtual ProtocolParams         getProtocolParams() const noexcept = 0;
+    CETL_NODISCARD virtual Expected<UniquePtr<session::IMessageRxSession>, AnyError> makeMessageRxSession(
+        session::MessageRxParams params) = 0;
+    CETL_NODISCARD virtual Expected<UniquePtr<session::IMessageTxSession>, AnyError> makeMessageTxSession(
+        session::MessageTxParams params) = 0;
+    CETL_NODISCARD virtual Expected<UniquePtr<session::IRequestRxSession>, AnyError> makeRequestRxSession(
+        session::RequestRxParams params) = 0;
+    CETL_NODISCARD virtual Expected<UniquePtr<session::IRequestTxSession>, AnyError> makeRequestTxSession(
+        session::RequestTxParams params) = 0;
+    CETL_NODISCARD virtual Expected<UniquePtr<session::IResponseRxSession>, AnyError> makeResponseRxSession(
+        session::ResponseRxParams params) = 0;
+    CETL_NODISCARD virtual Expected<UniquePtr<session::IResponseTxSession>, AnyError> makeResponseTxSession(
+        session::ResponseTxParams params) = 0;
 
 };  // ITransport
 

--- a/include/libcyphal/types.hpp
+++ b/include/libcyphal/types.hpp
@@ -8,6 +8,7 @@
 
 #include <cetl/pf17/cetlpf.hpp>
 #include <cetl/pf17/attribute.hpp>
+#include <cetl/pmr/memory.hpp>
 
 #include <cstdint>
 #include <chrono>
@@ -46,6 +47,13 @@ struct MonotonicClock final
 
 using TimePoint = MonotonicClock::time_point;
 using Duration  = MonotonicClock::duration;
+
+template <typename T>
+using UniquePtr = std::unique_ptr<T, cetl::pmr::MemoryResourceDeleter<cetl::pf17::pmr::memory_resource>>;
+
+// TODO: Maybe introduce `cetl::expected` at CETL repo.
+template <typename Success, typename Failure>
+using Expected = cetl::variant<Success, Failure>;
 
 }  // namespace libcyphal
 

--- a/include/libcyphal/types.hpp
+++ b/include/libcyphal/types.hpp
@@ -8,6 +8,7 @@
 
 #include <cetl/pf17/cetlpf.hpp>
 #include <cetl/pf17/attribute.hpp>
+#include <cetl/pf20/cetlpf.hpp>
 #include <cetl/pmr/memory.hpp>
 
 #include <cstdint>
@@ -16,6 +17,19 @@
 
 namespace libcyphal
 {
+
+enum class Priority
+{
+
+    Exceptional = 0,
+    Immediate   = 1,
+    Fast        = 2,
+    High        = 3,
+    Nominal     = 4,  ///< Nominal priority level should be the default.
+    Low         = 5,
+    Slow        = 6,
+    Optional    = 7,
+};
 
 /// @brief The internal time representation is in microseconds.
 ///

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -18,11 +18,11 @@ endif()
 #   We generate individual test binaires so we can record which test generated
 #   what coverage. We also allow test authors to generate coverage reports for
 #   just one test allowing for faster iteration.
-file(GLOB NATIVE_TESTS
+file(GLOB_RECURSE NATIVE_TESTS
     LIST_DIRECTORIES false
     CONFIGURE_DEPENDS
     RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-    test_*.cpp
+    test_*.cpp **/test_*.cpp
 )
 
 set(ALL_TESTS_BUILD "")

--- a/test/unittest/transport/test_dynamic_buffer.cpp
+++ b/test/unittest/transport/test_dynamic_buffer.cpp
@@ -1,0 +1,105 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#include "libcyphal/transport/dynamic_buffer.hpp"
+
+#include <gmock/gmock.h>
+
+using cetl::type_id_type;
+using cetl::rtti_helper;
+
+using DynamicBuffer = libcyphal::transport::DynamicBuffer;
+
+using testing::Return;
+using testing::StrictMock;
+
+namespace
+{
+
+class InterfaceMock : public DynamicBuffer::Interface
+{
+public:
+    MOCK_METHOD(void, moved, ());
+    MOCK_METHOD(void, deinit, ());
+
+    MOCK_METHOD(std::size_t, size, (), (const override));
+    MOCK_METHOD(std::size_t, copy, (const std::size_t, void* const, const std::size_t), (const override));
+};
+class InterfaceWrapper : public rtti_helper<type_id_type<0x01>, DynamicBuffer::Interface>
+{
+public:
+    explicit InterfaceWrapper(InterfaceMock* mock)
+        : mock_{mock}
+    {
+    }
+    InterfaceWrapper(InterfaceWrapper&& other) noexcept
+    {
+        move_from(std::move(other));
+    }
+    InterfaceWrapper& operator=(InterfaceWrapper&& other) noexcept
+    {
+        move_from(std::move(other));
+        return *this;
+    }
+    ~InterfaceWrapper() override
+    {
+        if (mock_ != nullptr)
+        {
+            mock_->deinit();
+            mock_ = nullptr;
+        }
+    }
+
+    // DynamicBuffer::Interface
+
+    CETL_NODISCARD std::size_t size() const override
+    {
+        return mock_ ? mock_->size() : 0;
+    }
+    CETL_NODISCARD std::size_t copy(const std::size_t offset_bytes,
+                                    void* const       destination,
+                                    const std::size_t length_bytes) const override
+    {
+        return mock_ ? mock_->copy(offset_bytes, destination, length_bytes) : 0;
+    }
+
+private:
+    InterfaceMock* mock_ = nullptr;
+
+    void move_from(InterfaceWrapper&& other)
+    {
+        mock_       = other.mock_;
+        other.mock_ = nullptr;
+
+        if (mock_ != nullptr)
+        {
+            mock_->moved();
+        }
+    }
+
+};  // InterfaceWrapper
+
+TEST(test_dynamic_buffer, move_and_size)
+{
+    StrictMock<InterfaceMock> interface_mock{};
+    EXPECT_CALL(interface_mock, moved()).Times(1 + 2 + 2);
+    EXPECT_CALL(interface_mock, deinit()).Times(1);
+    EXPECT_CALL(interface_mock, size()).Times(3).WillRepeatedly(Return(42));
+
+    {
+        DynamicBuffer src{InterfaceWrapper{&interface_mock}};  //< +1 move
+        EXPECT_EQ(42, src.size());
+
+        DynamicBuffer dst{std::move(src)};  //< +2 moves b/c of `cetl::any` specifics (via swap with tmp)
+        EXPECT_EQ(0, src.size());
+        EXPECT_EQ(42, dst.size());
+
+        src = std::move(dst);  //< +2 moves
+        EXPECT_EQ(42, src.size());
+        EXPECT_EQ(0, dst.size());
+    }
+}
+
+}  // namespace


### PR DESCRIPTION
- Added `ITransport::makeMessage[Rx|Tx]Session` methods
- Added `ITransport::make[Request|Response][Rx|Tx]Session` methods
- Added `Priority`, `[Service]TransferMetadata`, `PayloadFragments`, `MessageRxTransfre` and `ServiceRxTransfer` types.
- Added`transport::AnyError`
- Added implementation of `DynamicBuffer`.

Also:
- fixed "Coverage" build flavor, and artifacts upload
- added `libcyphal::UniquePtr` & `libcyphal::Expected`
- fixed "rule of five" deficiency