### PR TITLE
Implemented `transport::can::TransportImpl::getProtocolParams`

### DIFF
--- a/cmake/modules/Findcetl.cmake
+++ b/cmake/modules/Findcetl.cmake
@@ -6,7 +6,7 @@
 
 include(FetchContent)
 set(cetl_GIT_REPOSITORY "https://github.com/OpenCyphal/cetl.git")
-set(cetl_GIT_TAG "c1c2ae21ed446a7b25394d0067f3f4bec43a881b")
+set(cetl_GIT_TAG "884f3b38e7857daa790ed6ba7031f7037fb81a2e")
 
 FetchContent_Declare(
     cetl

--- a/include/libcyphal/transport/can/transport.hpp
+++ b/include/libcyphal/transport/can/transport.hpp
@@ -188,7 +188,8 @@ CETL_NODISCARD inline Expected<UniquePtr<ICanTransport>, FactoryError> makeTrans
     // - At least one media interface must be provided.
     // - If a local node ID is provided, it must be within the valid range.
     //
-    const auto media_count = std::count_if(media.cbegin(), media.cend(), [](auto m) { return m != nullptr; });
+    const auto media_count =
+        static_cast<std::size_t>(std::count_if(media.cbegin(), media.cend(), [](auto m) { return m != nullptr; }));
     if (media_count == 0)
     {
         return ArgumentError{};
@@ -199,7 +200,7 @@ CETL_NODISCARD inline Expected<UniquePtr<ICanTransport>, FactoryError> makeTrans
     }
 
     libcyphal::detail::VarArray<IMedia*> media_array{MaxMediaInterfaces, &memory};
-    media_array.reserve(static_cast<std::size_t>(media_count));
+    media_array.reserve(media_count);
     std::copy_if(media.cbegin(), media.cend(), std::back_inserter(media_array), [](auto m) { return m != nullptr; });
     CETL_DEBUG_ASSERT(!media_array.empty() && (media_array.size() == media_count), "");
 

--- a/include/libcyphal/transport/defines.hpp
+++ b/include/libcyphal/transport/defines.hpp
@@ -80,6 +80,9 @@ struct ServiceRxTransfer final
     DynamicBuffer           payload;
 };
 
+/// @brief Defines maximum number of media interfaces that can be used in a Cyphal transport.
+constexpr std::size_t MaxMediaInterfaces = 3;
+
 }  // namespace transport
 }  // namespace libcyphal
 

--- a/include/libcyphal/transport/udp/transport.hpp
+++ b/include/libcyphal/transport/udp/transport.hpp
@@ -26,9 +26,9 @@ namespace detail
 class TransportImpl final : public IUdpTransport
 {
 public:
-    // IUpdTransport
+    // MARK: IUpdTransport
 
-    // ITransport
+    // MARK: ITransport
 
     CETL_NODISCARD cetl::optional<NodeId> getLocalNodeId() const noexcept override
     {
@@ -70,7 +70,7 @@ public:
         return NotImplementedError{};
     }
 
-    // IRunnable
+    // MARK: IRunnable
 
     void run(const TimePoint) override {}
 
@@ -79,13 +79,13 @@ public:
 }  // namespace detail
 
 CETL_NODISCARD inline Expected<UniquePtr<IUdpTransport>, FactoryError> makeTransport(
-    cetl::pmr::memory_resource&  memory,
-    IMultiplexer&                mux,
-    const std::array<IMedia*, 3> media,  // TODO: replace with `cetl::span<IMedia*>`
-    const cetl::optional<NodeId> local_node_id)
+    cetl::pmr::memory_resource&                   memory,
+    IMultiplexer&                                 multiplexer,
+    const std::array<IMedia*, MaxMediaInterfaces> media,  // TODO: replace with `cetl::span<IMedia*>`
+    const cetl::optional<NodeId>                  local_node_id)
 {
     // TODO: Use these!
-    (void) mux;
+    (void) multiplexer;
     (void) media;
     (void) memory;
     (void) local_node_id;

--- a/include/libcyphal/types.hpp
+++ b/include/libcyphal/types.hpp
@@ -10,6 +10,7 @@
 #include <cetl/pf17/attribute.hpp>
 #include <cetl/pf20/cetlpf.hpp>
 #include <cetl/pmr/memory.hpp>
+#include <cetl/variable_length_array.hpp>
 
 #include <cstdint>
 #include <chrono>
@@ -55,6 +56,16 @@ using UniquePtr = cetl::pmr::Factory::unique_ptr_t<cetl::pmr::polymorphic_alloca
 // TODO: Maybe introduce `cetl::expected` at CETL repo.
 template <typename Success, typename Failure>
 using Expected = cetl::variant<Success, Failure>;
+
+namespace detail
+{
+template <typename T>
+using PmrAllocator = cetl::pmr::polymorphic_allocator<T>;
+
+template <typename T>
+using VarArray = cetl::VariableLengthArray<T, PmrAllocator<T>>;
+
+}  // namespace detail
 
 }  // namespace libcyphal
 


### PR DESCRIPTION
- `cetl::VariableLengthArray` is now in use to store CAN transport media interfaces.
- min MTU from all media is reported by the `ICanTransport::getProtocolParams`.
- added corresponding unit tests (to cover `getProtocolParams`).

Also:
- a bit reworked (simplified) canard memory alloc/free