### PR TITLE
No CETL_NODISCARD for most of the public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ![Cyphal](docs/images/html/opencyphal_logo.svg) Cyphal stack in C++
 ===================
 
-[![Build Status](https://badge.buildkite.com/af844974c06af6406e3b2192d98298b02b30f6ebebb5f8b16c.svg)](https://buildkite.com/uavcan/libcyphal-v1)
+[![Build Status](https://github.com/OpenCyphal-Garage/libcyphal/actions/workflows/tests.yml/badge.svg)](https://github.com/OpenCyphal-Garage/libcyphal)
 [![Forum](https://img.shields.io/discourse/https/forum.opencyphal.org/users.svg)](https://forum.opencyphal.org)
-[![Sonarqube Badge](https://sonarcloud.io/api/project_badges/measure?project=UAVCAN_libuavcan&metric=alert_status)](https://sonarcloud.io/dashboard?id=UAVCAN_libuavcan)
-[![Sonarqube Coverage](https://sonarcloud.io/api/project_badges/measure?project=UAVCAN_libuavcan&metric=coverage)](https://sonarcloud.io/dashboard?id=UAVCAN_libuavcan)
+[![Sonarqube Badge](https://sonarcloud.io/api/project_badges/measure?project=OpenCyphal-Garage_libcyphal&metric=alert_status)](https://sonarcloud.io/project/overview?id=OpenCyphal-Garage_libcyphal)
+[![Sonarqube Coverage](https://sonarcloud.io/api/project_badges/measure?project=OpenCyphal-Garage_libcyphal&metric=coverage)](https://sonarcloud.io/project/overview?id=OpenCyphal-Garage_libcyphal)
 [![Documentation](https://img.shields.io/badge/docs-passing-green.svg)](https://opencyphal.org/libcyphal/)
 
 > **WARNING** libcyphal v1 is not yet complete. This is a work-in-progress.
@@ -12,4 +12,3 @@
 Portable reference implementation of the [Cyphal protocol stack](https://opencyphal.org) in C++ for embedded systems, Linux, and POSIX-compliant RTOSs.
 
 Cyphal is a lightweight protocol designed for reliable communication in aerospace and robotic applications over robust vehicular networks.
-

--- a/cmake/modules/Findcetl.cmake
+++ b/cmake/modules/Findcetl.cmake
@@ -6,7 +6,7 @@
 
 include(FetchContent)
 set(cetl_GIT_REPOSITORY "https://github.com/OpenCyphal/cetl.git")
-set(cetl_GIT_TAG "10fbb2b7b89473d68e73db7235848b0692169e5a")
+set(cetl_GIT_TAG "63a118441a80078ebfeabf509c342bc0480a50b2")
 
 FetchContent_Declare(
     cetl

--- a/include/libcyphal/transport/can/delegate.hpp
+++ b/include/libcyphal/transport/can/delegate.hpp
@@ -50,16 +50,13 @@ class TransportDelegate
 public:
     /// @brief RAII class to manage memory allocated by Canard library.
     ///
-    /// NOSONAR cpp:S5008 for `void*` are unavoidable: integration with low-level C code of Canard memory management.
     /// NOSONAR cpp:S4963 for below `class CanardMemory` - we do directly handle resources here.
     ///
     class CanardMemory final  // NOSONAR cpp:S4963
         : public cetl::rtti_helper<CanardMemoryTypeIdType, ScatteredBuffer::IStorage>
     {
     public:
-        CanardMemory(TransportDelegate& delegate,
-                     void* const        buffer,  // NOSONAR cpp:S5008
-                     const std::size_t  payload_size)
+        CanardMemory(TransportDelegate& delegate, cetl::byte* const buffer, const std::size_t payload_size)
             : delegate_{delegate}
             , buffer_{buffer}
             , payload_size_{payload_size}
@@ -93,10 +90,8 @@ public:
             return payload_size_;
         }
 
-        // NOSONAR cpp:S5008 is unavoidable: integration with low-level Lizard memory access.
-        //
         CETL_NODISCARD std::size_t copy(const std::size_t offset_bytes,
-                                        void* const       destination,  // NOSONAR cpp:S5008
+                                        cetl::byte* const destination,
                                         const std::size_t length_bytes) const override
         {
             CETL_DEBUG_ASSERT((destination != nullptr) || (length_bytes == 0),
@@ -110,7 +105,7 @@ public:
             const std::size_t bytes_to_copy = std::min(length_bytes, payload_size_ - offset_bytes);
             // Next nolint is unavoidable: we need offset from the beginning of the buffer.
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            (void) std::memmove(destination, static_cast<cetl::byte*>(buffer_) + offset_bytes, bytes_to_copy);
+            (void) std::memmove(destination, buffer_ + offset_bytes, bytes_to_copy);
             return bytes_to_copy;
         }
 
@@ -118,7 +113,7 @@ public:
         // MARK: Data members:
 
         TransportDelegate& delegate_;
-        void*              buffer_;  // NOSONAR cpp:S5008
+        cetl::byte*        buffer_;
         std::size_t        payload_size_;
 
     };  // CanardMemory

--- a/include/libcyphal/transport/can/delegate.hpp
+++ b/include/libcyphal/transport/can/delegate.hpp
@@ -13,7 +13,6 @@
 
 #include <canard.h>
 #include <cetl/cetl.hpp>
-#include <cetl/pf17/attribute.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 #include <cetl/rtti.hpp>
 

--- a/include/libcyphal/transport/can/media.hpp
+++ b/include/libcyphal/transport/can/media.hpp
@@ -10,7 +10,6 @@
 #include "libcyphal/types.hpp"
 
 #include <cetl/cetl.hpp>
-#include <cetl/pf17/attribute.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 #include <cetl/pf20/cetlpf.hpp>
 

--- a/include/libcyphal/transport/can/media.hpp
+++ b/include/libcyphal/transport/can/media.hpp
@@ -68,20 +68,22 @@ public:
     ///
     /// @return Returns `nullopt` on success; otherwise some `MediaError` in case of a low-level error.
     ///
-    CETL_NODISCARD virtual cetl::optional<MediaError> setFilters(const Filters filters) noexcept = 0;
+    virtual cetl::optional<MediaError> setFilters(const Filters filters) noexcept = 0;
 
     /// @brief Schedules the frame for transmission asynchronously and return immediately.
     ///
     /// @return Returns `true` if accepted or already timed out; `false` to try again later.
     ///
-    CETL_NODISCARD virtual Expected<bool, MediaError> push(const TimePoint                    deadline,
-                                                           const CanId                        can_id,
-                                                           const cetl::span<const cetl::byte> payload) noexcept = 0;
+    virtual Expected<bool, MediaError> push(const TimePoint                    deadline,
+                                            const CanId                        can_id,
+                                            const cetl::span<const cetl::byte> payload) noexcept = 0;
 
     /// @brief Takes the next payload fragment (aka CAN frame) from the reception queue unless it's empty.
     ///
     /// @param payload_buffer The payload of the frame will be written into the mutable `payload_buffer` (aka span).
     /// @return Description of a received fragment if available; otherwise an empty optional is returned immediately.
+    ///         `nodiscard` is used to prevent ignoring the return value, which contains not only possible media error,
+    ///         but also important metadata (like `payload_size` field for further parsing of the result payload).
     ///
     CETL_NODISCARD virtual Expected<cetl::optional<RxMetadata>, MediaError> pop(
         const cetl::span<cetl::byte> payload_buffer) noexcept = 0;

--- a/include/libcyphal/transport/can/msg_rx_session.hpp
+++ b/include/libcyphal/transport/can/msg_rx_session.hpp
@@ -156,7 +156,9 @@ private:
                 : cetl::make_optional<NodeId>(transfer.metadata.remote_node_id);
 
         const MessageTransferMetadata   meta{transfer_id, timestamp, priority, publisher_node_id};
-        TransportDelegate::CanardMemory canard_memory{delegate_, transfer.payload, transfer.payload_size};
+        TransportDelegate::CanardMemory canard_memory{delegate_,
+                                                      static_cast<cetl::byte*>(transfer.payload),
+                                                      transfer.payload_size};
 
         (void) last_rx_transfer_.emplace(MessageRxTransfer{meta, ScatteredBuffer{std::move(canard_memory)}});
     }

--- a/include/libcyphal/transport/can/msg_rx_session.hpp
+++ b/include/libcyphal/transport/can/msg_rx_session.hpp
@@ -15,7 +15,6 @@
 
 #include <canard.h>
 #include <cetl/cetl.hpp>
-#include <cetl/pf17/attribute.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 
 #include <chrono>

--- a/include/libcyphal/transport/can/msg_tx_session.hpp
+++ b/include/libcyphal/transport/can/msg_tx_session.hpp
@@ -14,7 +14,7 @@
 #include "libcyphal/types.hpp"
 
 #include <canard.h>
-#include <cetl/pf17/attribute.hpp>
+#include <cetl/cetl.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 
 namespace libcyphal

--- a/include/libcyphal/transport/can/svc_rx_sessions.hpp
+++ b/include/libcyphal/transport/can/svc_rx_sessions.hpp
@@ -159,7 +159,9 @@ private:
         const auto timestamp      = TimePoint{std::chrono::microseconds{transfer.timestamp_usec}};
 
         const ServiceTransferMetadata   meta{transfer_id, timestamp, priority, remote_node_id};
-        TransportDelegate::CanardMemory canard_memory{delegate_, transfer.payload, transfer.payload_size};
+        TransportDelegate::CanardMemory canard_memory{delegate_,
+                                                      static_cast<cetl::byte*>(transfer.payload),
+                                                      transfer.payload_size};
 
         (void) last_rx_transfer_.emplace(ServiceRxTransfer{meta, ScatteredBuffer{std::move(canard_memory)}});
     }

--- a/include/libcyphal/transport/can/svc_rx_sessions.hpp
+++ b/include/libcyphal/transport/can/svc_rx_sessions.hpp
@@ -15,7 +15,6 @@
 
 #include <canard.h>
 #include <cetl/cetl.hpp>
-#include <cetl/pf17/attribute.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 
 #include <chrono>

--- a/include/libcyphal/transport/can/svc_tx_sessions.hpp
+++ b/include/libcyphal/transport/can/svc_tx_sessions.hpp
@@ -14,7 +14,7 @@
 #include "libcyphal/types.hpp"
 
 #include <canard.h>
-#include <cetl/pf17/attribute.hpp>
+#include <cetl/cetl.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 
 namespace libcyphal

--- a/include/libcyphal/transport/can/transport.hpp
+++ b/include/libcyphal/transport/can/transport.hpp
@@ -22,7 +22,7 @@
 #include "libcyphal/types.hpp"
 
 #include <canard.h>
-#include <cetl/pf17/attribute.hpp>
+#include <cetl/cetl.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 #include <cetl/pf20/cetlpf.hpp>
 

--- a/include/libcyphal/transport/can/transport.hpp
+++ b/include/libcyphal/transport/can/transport.hpp
@@ -16,7 +16,6 @@
 #include "libcyphal/transport/contiguous_payload.hpp"
 #include "libcyphal/transport/errors.hpp"
 #include "libcyphal/transport/msg_sessions.hpp"
-#include "libcyphal/transport/multiplexer.hpp"
 #include "libcyphal/transport/svc_sessions.hpp"
 #include "libcyphal/transport/transport.hpp"
 #include "libcyphal/transport/types.hpp"
@@ -112,7 +111,6 @@ class TransportImpl final : public ICanTransport, private TransportDelegate  // 
 public:
     CETL_NODISCARD static Expected<UniquePtr<ICanTransport>, FactoryError> make(
         cetl::pmr::memory_resource&  memory,
-        IMultiplexer&                multiplexer,
         const cetl::span<IMedia*>    media,
         const std::size_t            tx_capacity,
         const cetl::optional<NodeId> local_node_id)
@@ -142,8 +140,7 @@ public:
 
         const auto canard_node_id = static_cast<CanardNodeID>(local_node_id.value_or(CANARD_NODE_ID_UNSET));
 
-        auto transport =
-            libcyphal::detail::makeUniquePtr<Spec>(memory, Spec{}, memory, multiplexer, media_array, canard_node_id);
+        auto transport = libcyphal::detail::makeUniquePtr<Spec>(memory, Spec{}, memory, media_array, canard_node_id);
         if (transport == nullptr)
         {
             return MemoryError{};
@@ -152,20 +149,13 @@ public:
         return transport;
     }
 
-    TransportImpl(Spec,
-                  cetl::pmr::memory_resource& memory,
-                  IMultiplexer&               multiplexer,
-                  MediaArray                  media_array,
-                  const CanardNodeID          canard_node_id)
+    TransportImpl(Spec, cetl::pmr::memory_resource& memory, MediaArray media_array, const CanardNodeID canard_node_id)
         : TransportDelegate{memory}
         , media_array_{std::move(media_array)}
         , should_reconfigure_filters_{false}
         , total_message_ports_{0}
         , total_service_ports_{0}
     {
-        // TODO: Use it!
-        (void) multiplexer;
-
         canard_instance().node_id = canard_node_id;
     }
 
@@ -654,14 +644,22 @@ private:
 
 }  // namespace detail
 
-CETL_NODISCARD inline Expected<UniquePtr<ICanTransport>, FactoryError> makeTransport(
-    cetl::pmr::memory_resource&  memory,
-    IMultiplexer&                multiplexer,
-    const cetl::span<IMedia*>    media,
-    const std::size_t            tx_capacity,
-    const cetl::optional<NodeId> local_node_id)
+/// @brief Makes a new CAN transport instance.
+///
+/// NB! Lifetime of the transport instance must never outlive `memory` and `media` instances.
+///
+/// @param memory Reference to a polymorphic memory resource to use for all allocations.
+/// @param media Collection of redundant media interfaces to use.
+/// @param tx_capacity Total number of frames that can be queued for transmission.
+/// @param local_node_id Optional id of the local node. Could be set (once!) later by `setLocalNodeId` call.
+/// @return Unique pointer to the new CAN transport instance or an error.
+///
+inline Expected<UniquePtr<ICanTransport>, FactoryError> makeTransport(cetl::pmr::memory_resource&  memory,
+                                                                      const cetl::span<IMedia*>    media,
+                                                                      const std::size_t            tx_capacity,
+                                                                      const cetl::optional<NodeId> local_node_id)
 {
-    return detail::TransportImpl::make(memory, multiplexer, media, tx_capacity, local_node_id);
+    return detail::TransportImpl::make(memory, media, tx_capacity, local_node_id);
 }
 
 }  // namespace can

--- a/include/libcyphal/transport/can/transport.hpp
+++ b/include/libcyphal/transport/can/transport.hpp
@@ -650,7 +650,7 @@ private:
 ///
 /// @param memory Reference to a polymorphic memory resource to use for all allocations.
 /// @param media Collection of redundant media interfaces to use.
-/// @param tx_capacity Total number of frames that can be queued for transmission.
+/// @param tx_capacity Total number of frames that can be queued for transmission per `IMedia` instance.
 /// @param local_node_id Optional id of the local node. Could be set (once!) later by `setLocalNodeId` call.
 /// @return Unique pointer to the new CAN transport instance or an error.
 ///

--- a/include/libcyphal/transport/can/transport.hpp
+++ b/include/libcyphal/transport/can/transport.hpp
@@ -651,7 +651,7 @@ private:
 /// @param memory Reference to a polymorphic memory resource to use for all allocations.
 /// @param media Collection of redundant media interfaces to use.
 /// @param tx_capacity Total number of frames that can be queued for transmission per `IMedia` instance.
-/// @param local_node_id Optional id of the local node. Could be set (once!) later by `setLocalNodeId` call.
+/// @param local_node_id Optional node-ID of the local node. Could be set (once!) later by `setLocalNodeId` call.
 /// @return Unique pointer to the new CAN transport instance or an error.
 ///
 inline Expected<UniquePtr<ICanTransport>, FactoryError> makeTransport(cetl::pmr::memory_resource&  memory,

--- a/include/libcyphal/transport/contiguous_payload.hpp
+++ b/include/libcyphal/transport/contiguous_payload.hpp
@@ -8,7 +8,7 @@
 
 #include "types.hpp"
 
-#include <cetl/pf17/attribute.hpp>
+#include <cetl/cetl.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 #include <cetl/pf20/cetlpf.hpp>
 

--- a/include/libcyphal/transport/msg_sessions.hpp
+++ b/include/libcyphal/transport/msg_sessions.hpp
@@ -10,7 +10,6 @@
 #include "session.hpp"
 #include "types.hpp"
 
-#include <cetl/pf17/attribute.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 
 #include <cstddef>

--- a/include/libcyphal/transport/msg_sessions.hpp
+++ b/include/libcyphal/transport/msg_sessions.hpp
@@ -34,7 +34,7 @@ struct MessageTxParams final
 class IMessageRxSession : public IRxSession
 {
 public:
-    CETL_NODISCARD virtual MessageRxParams getParams() const noexcept = 0;
+    virtual MessageRxParams getParams() const noexcept = 0;
 
     /// @brief Receives a message from the transport layer.
     ///
@@ -42,14 +42,14 @@ public:
     ///
     /// @return A message transfer if available; otherwise an empty optional.
     ///
-    CETL_NODISCARD virtual cetl::optional<MessageRxTransfer> receive() = 0;
+    virtual cetl::optional<MessageRxTransfer> receive() = 0;
 
 };  // IMessageRxSession
 
 class IMessageTxSession : public ITxSession
 {
 public:
-    CETL_NODISCARD virtual MessageTxParams getParams() const noexcept = 0;
+    virtual MessageTxParams getParams() const noexcept = 0;
 
     /// @brief Sends a message to the transport layer.
     ///
@@ -57,8 +57,8 @@ public:
     /// @param payload_fragments Segments of the message payload.
     /// @return `nullopt` in case of success; otherwise a transport error.
     ///
-    CETL_NODISCARD virtual cetl::optional<AnyError> send(const TransferMetadata& metadata,
-                                                         const PayloadFragments  payload_fragments) = 0;
+    virtual cetl::optional<AnyError> send(const TransferMetadata& metadata,
+                                          const PayloadFragments  payload_fragments) = 0;
 };  // IMessageTxSession
 
 }  // namespace transport

--- a/include/libcyphal/transport/scattered_buffer.hpp
+++ b/include/libcyphal/transport/scattered_buffer.hpp
@@ -165,8 +165,10 @@ public:
     /// @param length_bytes The number of bytes to copy.
     /// @return The number of bytes copied.
     ///
+    /// NOSONAR cpp:S5008 below currently unavoidable. Could be fixed if nunavut provides `cetl::byte*` support.
+    ///
     std::size_t copy(const std::size_t offset_bytes,
-                     void* const       destination,  // NOSONAR : integration with low-level Lizard memory access.
+                     void* const       destination,  // NOSONAR : cpp:S5008
                      const std::size_t length_bytes) const
     {
         if (storage_ == nullptr)

--- a/include/libcyphal/transport/scattered_buffer.hpp
+++ b/include/libcyphal/transport/scattered_buffer.hpp
@@ -6,7 +6,6 @@
 #ifndef LIBCYPHAL_TRANSPORT_SCATTERED_BUFFER_HPP_INCLUDED
 #define LIBCYPHAL_TRANSPORT_SCATTERED_BUFFER_HPP_INCLUDED
 
-#include <cetl/pf17/attribute.hpp>
 #include <cetl/rtti.hpp>
 #include <cetl/unbounded_variant.hpp>
 

--- a/include/libcyphal/transport/svc_sessions.hpp
+++ b/include/libcyphal/transport/svc_sessions.hpp
@@ -52,19 +52,19 @@ public:
     ///
     /// @return A service transfer if available; otherwise an empty optional.
     ///
-    CETL_NODISCARD virtual cetl::optional<ServiceRxTransfer> receive() = 0;
+    virtual cetl::optional<ServiceRxTransfer> receive() = 0;
 };
 
 class IRequestRxSession : public ISvcRxSession
 {
 public:
-    CETL_NODISCARD virtual RequestRxParams getParams() const noexcept = 0;
+    virtual RequestRxParams getParams() const noexcept = 0;
 };
 
 class IRequestTxSession : public ITxSession
 {
 public:
-    CETL_NODISCARD virtual RequestTxParams getParams() const noexcept = 0;
+    virtual RequestTxParams getParams() const noexcept = 0;
 
     /// @brief Sends a service request to the transport layer.
     ///
@@ -72,20 +72,20 @@ public:
     /// @param payload_fragments Segments of the request payload.
     /// @return `nullopt` in case of success; otherwise a transport error.
     ///
-    CETL_NODISCARD virtual cetl::optional<AnyError> send(const TransferMetadata& metadata,
-                                                         const PayloadFragments  payload_fragments) = 0;
+    virtual cetl::optional<AnyError> send(const TransferMetadata& metadata,
+                                          const PayloadFragments  payload_fragments) = 0;
 };
 
 class IResponseRxSession : public ISvcRxSession
 {
 public:
-    CETL_NODISCARD virtual ResponseRxParams getParams() const noexcept = 0;
+    virtual ResponseRxParams getParams() const noexcept = 0;
 };
 
 class IResponseTxSession : public ITxSession
 {
 public:
-    CETL_NODISCARD virtual ResponseTxParams getParams() const noexcept = 0;
+    virtual ResponseTxParams getParams() const noexcept = 0;
 
     /// @brief Sends a service response to the transport layer.
     ///
@@ -93,8 +93,8 @@ public:
     /// @param payload_fragments Segments of the response payload.
     /// @return `nullopt` in case of success; otherwise a transport error.
     ///
-    CETL_NODISCARD virtual cetl::optional<AnyError> send(const ServiceTransferMetadata& metadata,
-                                                         const PayloadFragments         payload_fragments) = 0;
+    virtual cetl::optional<AnyError> send(const ServiceTransferMetadata& metadata,
+                                          const PayloadFragments         payload_fragments) = 0;
 };
 
 }  // namespace transport

--- a/include/libcyphal/transport/svc_sessions.hpp
+++ b/include/libcyphal/transport/svc_sessions.hpp
@@ -9,7 +9,6 @@
 #include "session.hpp"
 #include "types.hpp"
 
-#include <cetl/pf17/attribute.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 
 #include <cstddef>

--- a/include/libcyphal/transport/transport.hpp
+++ b/include/libcyphal/transport/transport.hpp
@@ -65,37 +65,37 @@ public:
 
     /// @brief Makes a message receive (RX) session.
     ///
-    /// Lifetime of the RX session must never outlive this transport interface.
+    /// The RX session must never outlive this transport interface.
     ///
     virtual Expected<UniquePtr<IMessageRxSession>, AnyError> makeMessageRxSession(const MessageRxParams& params) = 0;
 
     /// @brief Makes a message transmit (TX) session.
     ///
-    /// Lifetime of the TX session must never outlive this transport interface.
+    /// The TX session must never outlive this transport interface.
     ///
     virtual Expected<UniquePtr<IMessageTxSession>, AnyError> makeMessageTxSession(const MessageTxParams& params) = 0;
 
     /// @brief Makes a service request receive (RX) session.
     ///
-    /// Lifetime of the RX session must never outlive this transport interface.
+    /// The RX session must never outlive this transport interface.
     ///
     virtual Expected<UniquePtr<IRequestRxSession>, AnyError> makeRequestRxSession(const RequestRxParams& params) = 0;
 
     /// @brief Makes a service request transmit (TX) session.
     ///
-    /// Lifetime of the TX session must never outlive this transport interface.
+    /// The TX session must never outlive this transport interface.
     ///
     virtual Expected<UniquePtr<IRequestTxSession>, AnyError> makeRequestTxSession(const RequestTxParams& params) = 0;
 
     /// @brief Makes a service response receive (RX) session.
     ///
-    /// Lifetime of the RX session must never outlive this transport interface.
+    /// The RX session must never outlive this transport interface.
     ///
     virtual Expected<UniquePtr<IResponseRxSession>, AnyError> makeResponseRxSession(const ResponseRxParams& params) = 0;
 
     /// @brief Makes a service response transmit (TX) session.
     ///
-    /// Lifetime of the TX session must never outlive this transport interface.
+    /// The TX session must never outlive this transport interface.
     ///
     virtual Expected<UniquePtr<IResponseTxSession>, AnyError> makeResponseTxSession(const ResponseTxParams& params) = 0;
 

--- a/include/libcyphal/transport/transport.hpp
+++ b/include/libcyphal/transport/transport.hpp
@@ -14,7 +14,6 @@
 #include "libcyphal/runnable.hpp"
 #include "libcyphal/types.hpp"
 
-#include <cetl/pf17/attribute.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 
 namespace libcyphal

--- a/include/libcyphal/transport/transport.hpp
+++ b/include/libcyphal/transport/transport.hpp
@@ -67,17 +67,11 @@ public:
     ///
     /// Lifetime of the RX session must never outlive this transport interface.
     ///
-    /// @param params Various initial parameters for the message RX session (like subject id and extent size).
-    /// @return Either a unique interface pointer to the message RX session, or an error.
-    ///
     virtual Expected<UniquePtr<IMessageRxSession>, AnyError> makeMessageRxSession(const MessageRxParams& params) = 0;
 
     /// @brief Makes a message transmit (TX) session.
     ///
     /// Lifetime of the TX session must never outlive this transport interface.
-    ///
-    /// @param params Various initial parameters for the message TX session (like subject id).
-    /// @return Either a unique interface pointer to the message TX session, or an error.
     ///
     virtual Expected<UniquePtr<IMessageTxSession>, AnyError> makeMessageTxSession(const MessageTxParams& params) = 0;
 
@@ -85,17 +79,11 @@ public:
     ///
     /// Lifetime of the RX session must never outlive this transport interface.
     ///
-    /// @param params Various initial parameters for the service request RX session (like service id and extent size).
-    /// @return Either a unique interface pointer to the service request RX session, or an error.
-    ///
     virtual Expected<UniquePtr<IRequestRxSession>, AnyError> makeRequestRxSession(const RequestRxParams& params) = 0;
 
     /// @brief Makes a service request transmit (TX) session.
     ///
     /// Lifetime of the TX session must never outlive this transport interface.
-    ///
-    /// @param params Various initial parameters for the service request TX session (like service id and server node).
-    /// @return Either a unique interface pointer to the service request TX session, or an error.
     ///
     virtual Expected<UniquePtr<IRequestTxSession>, AnyError> makeRequestTxSession(const RequestTxParams& params) = 0;
 
@@ -103,17 +91,11 @@ public:
     ///
     /// Lifetime of the RX session must never outlive this transport interface.
     ///
-    /// @param params Various initial parameters for the service response RX session (like service id and etc).
-    /// @return Either a unique interface pointer to the service response RX session, or an error.
-    ///
     virtual Expected<UniquePtr<IResponseRxSession>, AnyError> makeResponseRxSession(const ResponseRxParams& params) = 0;
 
     /// @brief Makes a service response transmit (TX) session.
     ///
     /// Lifetime of the TX session must never outlive this transport interface.
-    ///
-    /// @param params Various initial parameters for the service response TX session (like service id).
-    /// @return Either a unique interface pointer to the service response TX session, or an error.
     ///
     virtual Expected<UniquePtr<IResponseTxSession>, AnyError> makeResponseTxSession(const ResponseTxParams& params) = 0;
 

--- a/include/libcyphal/transport/transport.hpp
+++ b/include/libcyphal/transport/transport.hpp
@@ -36,7 +36,7 @@ public:
     /// @see can::IMedia::getMtu()
     /// @see udp::IMedia::getMtu()
     ///
-    CETL_NODISCARD virtual ProtocolParams getProtocolParams() const noexcept = 0;
+    virtual ProtocolParams getProtocolParams() const noexcept = 0;
 
     /// @brief Gets the local node ID (if any).
     ///
@@ -46,7 +46,7 @@ public:
     /// @return The node ID previously assigned to this transport interface (via `setLocalNodeId`).
     ///         Otherwise it's `nullopt` for an anonymous node.
     ///
-    CETL_NODISCARD virtual cetl::optional<NodeId> getLocalNodeId() const noexcept = 0;
+    virtual cetl::optional<NodeId> getLocalNodeId() const noexcept = 0;
 
     /// @brief Sets the local node ID.
     ///
@@ -61,20 +61,61 @@ public:
     /// @return `nullopt` on successful set (or when node ID is the same).
     ///         Otherwise an `ArgumentError` in case of the subsequent calls or ID out of range.
     ///
-    CETL_NODISCARD virtual cetl::optional<ArgumentError> setLocalNodeId(const NodeId node_id) noexcept = 0;
+    virtual cetl::optional<ArgumentError> setLocalNodeId(const NodeId node_id) noexcept = 0;
 
-    CETL_NODISCARD virtual Expected<UniquePtr<IMessageRxSession>, AnyError> makeMessageRxSession(
-        const MessageRxParams& params) = 0;
-    CETL_NODISCARD virtual Expected<UniquePtr<IMessageTxSession>, AnyError> makeMessageTxSession(
-        const MessageTxParams& params) = 0;
-    CETL_NODISCARD virtual Expected<UniquePtr<IRequestRxSession>, AnyError> makeRequestRxSession(
-        const RequestRxParams& params) = 0;
-    CETL_NODISCARD virtual Expected<UniquePtr<IRequestTxSession>, AnyError> makeRequestTxSession(
-        const RequestTxParams& params) = 0;
-    CETL_NODISCARD virtual Expected<UniquePtr<IResponseRxSession>, AnyError> makeResponseRxSession(
-        const ResponseRxParams& params) = 0;
-    CETL_NODISCARD virtual Expected<UniquePtr<IResponseTxSession>, AnyError> makeResponseTxSession(
-        const ResponseTxParams& params) = 0;
+    /// @brief Makes a message receive (RX) session.
+    ///
+    /// Lifetime of the RX session must never outlive this transport interface.
+    ///
+    /// @param params Various initial parameters for the message RX session (like subject id and extent size).
+    /// @return Either a unique interface pointer to the message RX session, or an error.
+    ///
+    virtual Expected<UniquePtr<IMessageRxSession>, AnyError> makeMessageRxSession(const MessageRxParams& params) = 0;
+
+    /// @brief Makes a message transmit (TX) session.
+    ///
+    /// Lifetime of the TX session must never outlive this transport interface.
+    ///
+    /// @param params Various initial parameters for the message TX session (like subject id).
+    /// @return Either a unique interface pointer to the message TX session, or an error.
+    ///
+    virtual Expected<UniquePtr<IMessageTxSession>, AnyError> makeMessageTxSession(const MessageTxParams& params) = 0;
+
+    /// @brief Makes a service request receive (RX) session.
+    ///
+    /// Lifetime of the RX session must never outlive this transport interface.
+    ///
+    /// @param params Various initial parameters for the service request RX session (like service id and extent size).
+    /// @return Either a unique interface pointer to the service request RX session, or an error.
+    ///
+    virtual Expected<UniquePtr<IRequestRxSession>, AnyError> makeRequestRxSession(const RequestRxParams& params) = 0;
+
+    /// @brief Makes a service request transmit (TX) session.
+    ///
+    /// Lifetime of the TX session must never outlive this transport interface.
+    ///
+    /// @param params Various initial parameters for the service request TX session (like service id and server node).
+    /// @return Either a unique interface pointer to the service request TX session, or an error.
+    ///
+    virtual Expected<UniquePtr<IRequestTxSession>, AnyError> makeRequestTxSession(const RequestTxParams& params) = 0;
+
+    /// @brief Makes a service response receive (RX) session.
+    ///
+    /// Lifetime of the RX session must never outlive this transport interface.
+    ///
+    /// @param params Various initial parameters for the service response RX session (like service id and etc).
+    /// @return Either a unique interface pointer to the service response RX session, or an error.
+    ///
+    virtual Expected<UniquePtr<IResponseRxSession>, AnyError> makeResponseRxSession(const ResponseRxParams& params) = 0;
+
+    /// @brief Makes a service response transmit (TX) session.
+    ///
+    /// Lifetime of the TX session must never outlive this transport interface.
+    ///
+    /// @param params Various initial parameters for the service response TX session (like service id).
+    /// @return Either a unique interface pointer to the service response TX session, or an error.
+    ///
+    virtual Expected<UniquePtr<IResponseTxSession>, AnyError> makeResponseTxSession(const ResponseTxParams& params) = 0;
 
 };  // ITransport
 

--- a/include/libcyphal/transport/udp/transport.hpp
+++ b/include/libcyphal/transport/udp/transport.hpp
@@ -128,11 +128,20 @@ private:
 
 }  // namespace detail
 
-CETL_NODISCARD inline Expected<UniquePtr<IUdpTransport>, FactoryError> makeTransport(
-    cetl::pmr::memory_resource&  memory,
-    IMultiplexer&                multiplexer,
-    const cetl::span<IMedia*>    media,
-    const cetl::optional<NodeId> local_node_id)
+/// @brief Makes a new UDP transport instance.
+///
+/// NB! Lifetime of the transport instance must never outlive `memory`, `media` and `multiplexer` instances.
+///
+/// @param memory Reference to a polymorphic memory resource to use for all allocations.
+/// @param multiplexer Interface of the multiplexer to use.
+/// @param media Collection of redundant media interfaces to use.
+/// @param local_node_id Optional id of the local node. Could be set (once!) later by `setLocalNodeId` call.
+/// @return Unique pointer to the new UDP transport instance or an error.
+///
+inline Expected<UniquePtr<IUdpTransport>, FactoryError> makeTransport(cetl::pmr::memory_resource&  memory,
+                                                                      IMultiplexer&                multiplexer,
+                                                                      const cetl::span<IMedia*>    media,
+                                                                      const cetl::optional<NodeId> local_node_id)
 {
     // TODO: Use these!
     (void) multiplexer;

--- a/include/libcyphal/transport/udp/transport.hpp
+++ b/include/libcyphal/transport/udp/transport.hpp
@@ -16,7 +16,7 @@
 #include "libcyphal/transport/types.hpp"
 #include "libcyphal/types.hpp"
 
-#include <cetl/pf17/attribute.hpp>
+#include <cetl/cetl.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 #include <cetl/pf20/cetlpf.hpp>
 #include <udpard.h>

--- a/include/libcyphal/types.hpp
+++ b/include/libcyphal/types.hpp
@@ -42,7 +42,7 @@ struct MonotonicClock final
     ///     return std::chrono::time_point_cast<time_point>(std::chrono::steady_clock::now());
     /// }
     /// ```
-    CETL_NODISCARD static time_point now() noexcept;
+    static time_point now() noexcept;
 
 };  // MonotonicClock
 
@@ -58,6 +58,7 @@ using Expected = cetl::variant<Success, Failure>;
 
 namespace detail
 {
+
 template <typename T>
 using PmrAllocator = cetl::pmr::polymorphic_allocator<T>;
 

--- a/include/libcyphal/types.hpp
+++ b/include/libcyphal/types.hpp
@@ -6,7 +6,7 @@
 #ifndef LIBCYPHAL_TYPES_HPP_INCLUDED
 #define LIBCYPHAL_TYPES_HPP_INCLUDED
 
-#include <cetl/pf17/attribute.hpp>
+#include <cetl/cetl.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 #include <cetl/pmr/memory.hpp>
 #include <cetl/variable_length_array.hpp>

--- a/test/unittest/test_utilities.hpp
+++ b/test/unittest/test_utilities.hpp
@@ -21,11 +21,18 @@ inline cetl::byte b(std::uint8_t b)
     return static_cast<cetl::byte>(b);
 }
 
+inline void fillIotaBytes(const cetl::span<cetl::byte> span, const cetl::byte init)
+{
+    std::iota(reinterpret_cast<std::uint8_t*>(span.data()),
+              reinterpret_cast<std::uint8_t*>(span.data() + span.size()),
+              static_cast<std::uint8_t>(init));
+}
+
 template <std::size_t N>
-std::array<cetl::byte, N> makeIotaArray(const std::uint8_t init)
+std::array<cetl::byte, N> makeIotaArray(const cetl::byte init)
 {
     std::array<cetl::byte, N> arr{};
-    std::iota(reinterpret_cast<std::uint8_t*>(arr.begin()), reinterpret_cast<std::uint8_t*>(arr.end()), init);
+    fillIotaBytes(arr, init);
     return arr;
 }
 

--- a/test/unittest/transport/can/test_can_msg_rx_session.cpp
+++ b/test/unittest/transport/can/test_can_msg_rx_session.cpp
@@ -8,7 +8,6 @@
 #include "../../test_utilities.hpp"
 #include "../../tracking_memory_resource.hpp"
 #include "../../virtual_time_scheduler.hpp"
-#include "../multiplexer_mock.hpp"
 #include "media_mock.hpp"
 
 #include <canard.h>
@@ -81,7 +80,7 @@ protected:
     {
         std::array<can::IMedia*, 1> media_array{&media_mock_};
 
-        auto maybe_transport = can::makeTransport(mr, mux_mock_, media_array, 0, {});
+        auto maybe_transport = can::makeTransport(mr, media_array, 0, {});
         EXPECT_THAT(maybe_transport, VariantWith<UniquePtr<can::ICanTransport>>(NotNull()));
         return cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
     }
@@ -92,7 +91,6 @@ protected:
     libcyphal::VirtualTimeScheduler scheduler_{};
     TrackingMemoryResource          mr_;
     StrictMock<can::MediaMock>      media_mock_{};
-    StrictMock<MultiplexerMock>     mux_mock_{};
     // NOLINTEND
 };
 

--- a/test/unittest/transport/can/test_can_msg_rx_session.cpp
+++ b/test/unittest/transport/can/test_can_msg_rx_session.cpp
@@ -80,7 +80,7 @@ protected:
     {
         std::array<can::IMedia*, 1> media_array{&media_mock_};
 
-        auto maybe_transport = can::makeTransport(mr, media_array, 0, {});
+        auto maybe_transport = can::makeTransport(mr, media_array, 0);
         EXPECT_THAT(maybe_transport, VariantWith<UniquePtr<can::ICanTransport>>(NotNull()));
         return cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
     }

--- a/test/unittest/transport/can/test_can_msg_tx_session.cpp
+++ b/test/unittest/transport/can/test_can_msg_tx_session.cpp
@@ -81,7 +81,7 @@ protected:
     {
         std::array<can::IMedia*, 1> media_array{&media_mock_};
 
-        auto maybe_transport = can::makeTransport(mr, media_array, 16, {});
+        auto maybe_transport = can::makeTransport(mr, media_array, 16);
         EXPECT_THAT(maybe_transport, VariantWith<UniquePtr<can::ICanTransport>>(NotNull()));
         return cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
     }

--- a/test/unittest/transport/can/test_can_msg_tx_session.cpp
+++ b/test/unittest/transport/can/test_can_msg_tx_session.cpp
@@ -8,7 +8,6 @@
 #include "../../test_utilities.hpp"
 #include "../../tracking_memory_resource.hpp"
 #include "../../virtual_time_scheduler.hpp"
-#include "../multiplexer_mock.hpp"
 #include "media_mock.hpp"
 
 #include <canard.h>
@@ -82,7 +81,7 @@ protected:
     {
         std::array<can::IMedia*, 1> media_array{&media_mock_};
 
-        auto maybe_transport = can::makeTransport(mr, mux_mock_, media_array, 16, {});
+        auto maybe_transport = can::makeTransport(mr, media_array, 16, {});
         EXPECT_THAT(maybe_transport, VariantWith<UniquePtr<can::ICanTransport>>(NotNull()));
         return cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
     }
@@ -92,7 +91,6 @@ protected:
     // NOLINTBEGIN
     libcyphal::VirtualTimeScheduler scheduler_{};
     TrackingMemoryResource          mr_;
-    StrictMock<MultiplexerMock>     mux_mock_{};
     StrictMock<can::MediaMock>      media_mock_{};
     // NOLINTEND
 };
@@ -232,7 +230,7 @@ TEST_F(TestCanMsgTxSession, send_7bytes_payload_with_500ms_timeout)
     scheduler_.runNow(+10s);
     const auto send_time = now();
 
-    const auto             payload = makeIotaArray<CANARD_MTU_CAN_CLASSIC - 1>('1');
+    const auto             payload = makeIotaArray<CANARD_MTU_CAN_CLASSIC - 1>(b('1'));
     const TransferMetadata metadata{0x03, send_time, Priority::High};
 
     auto maybe_error = session->send(metadata, makeSpansFrom(payload));
@@ -265,8 +263,8 @@ TEST_F(TestCanMsgTxSession, send_when_no_memory_for_contiguous_payload)
     auto transport = makeTransport(mr_mock);
 
     // Emulate that there is no memory available for the expected contiguous payload.
-    const auto payload1 = makeIotaArray<1>('0');
-    const auto payload2 = makeIotaArray<2>('1');
+    const auto payload1 = makeIotaArray<1>(b('0'));
+    const auto payload2 = makeIotaArray<2>(b('1'));
     EXPECT_CALL(mr_mock, do_allocate(sizeof(payload1) + sizeof(payload2), _)).WillOnce(Return(nullptr));
 
     auto maybe_session = transport->makeMessageTxSession({17});

--- a/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
@@ -7,7 +7,6 @@
 #include "../../test_utilities.hpp"
 #include "../../tracking_memory_resource.hpp"
 #include "../../virtual_time_scheduler.hpp"
-#include "../multiplexer_mock.hpp"
 #include "media_mock.hpp"
 
 #include <canard.h>
@@ -86,7 +85,7 @@ protected:
         // but it's not possible due to CETL issue https://github.com/OpenCyphal/CETL/issues/119.
         const auto opt_local_node_id = cetl::optional<NodeId>{local_node_id};
 
-        auto maybe_transport = can::makeTransport(mr, mux_mock_, media_array, 0, opt_local_node_id);
+        auto maybe_transport = can::makeTransport(mr, media_array, 0, opt_local_node_id);
         EXPECT_THAT(maybe_transport, VariantWith<UniquePtr<can::ICanTransport>>(NotNull()));
         return cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
     }
@@ -97,7 +96,6 @@ protected:
     libcyphal::VirtualTimeScheduler scheduler_{};
     TrackingMemoryResource          mr_;
     StrictMock<can::MediaMock>      media_mock_{};
-    StrictMock<MultiplexerMock>     mux_mock_{};
     // NOLINTEND
 };
 

--- a/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
@@ -81,13 +81,13 @@ protected:
     {
         std::array<can::IMedia*, 1> media_array{&media_mock_};
 
-        // TODO: `local_node_id` could be just passed to `can::makeTransport` as an argument,
-        // but it's not possible due to CETL issue https://github.com/OpenCyphal/CETL/issues/119.
-        const auto opt_local_node_id = cetl::optional<NodeId>{local_node_id};
-
-        auto maybe_transport = can::makeTransport(mr, media_array, 0, opt_local_node_id);
+        auto maybe_transport = can::makeTransport(mr, media_array, 0);
         EXPECT_THAT(maybe_transport, VariantWith<UniquePtr<can::ICanTransport>>(NotNull()));
-        return cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
+        auto transport = cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
+
+        transport->setLocalNodeId(local_node_id);
+
+        return transport;
     }
 
     // MARK: Data members:

--- a/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
@@ -76,13 +76,13 @@ protected:
     {
         std::array<can::IMedia*, 1> media_array{&media_mock_};
 
-        // TODO: `local_node_id` could be just passed to `can::makeTransport` as an argument,
-        // but it's not possible due to CETL issue https://github.com/OpenCyphal/CETL/issues/119.
-        const auto opt_local_node_id = cetl::optional<NodeId>{local_node_id};
-
-        auto maybe_transport = can::makeTransport(mr, media_array, 16, opt_local_node_id);
+        auto maybe_transport = can::makeTransport(mr, media_array, 16);
         EXPECT_THAT(maybe_transport, VariantWith<UniquePtr<can::ICanTransport>>(NotNull()));
-        return cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
+        auto transport = cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
+
+        transport->setLocalNodeId(local_node_id);
+
+        return transport;
     }
 
     // MARK: Data members:
@@ -185,7 +185,7 @@ TEST_F(TestCanSvcTxSessions, send_request_with_argument_error)
     // Make initially anonymous node transport.
     //
     std::array<can::IMedia*, 1> media_array{&media_mock_};
-    auto                        maybe_transport = can::makeTransport(mr_, media_array, 2, {});
+    auto                        maybe_transport = can::makeTransport(mr_, media_array, 2);
     ASSERT_THAT(maybe_transport, VariantWith<UniquePtr<can::ICanTransport>>(NotNull()));
     auto transport = cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
 
@@ -317,7 +317,7 @@ TEST_F(TestCanSvcTxSessions, send_respose_with_argument_error)
     // Make initially anonymous node transport.
     //
     std::array<can::IMedia*, 1> media_array{&media_mock_};
-    auto                        maybe_transport = can::makeTransport(mr_, media_array, 2, {});
+    auto                        maybe_transport = can::makeTransport(mr_, media_array, 2);
     ASSERT_THAT(maybe_transport, VariantWith<UniquePtr<can::ICanTransport>>(NotNull()));
     auto transport = cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
 

--- a/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
@@ -7,7 +7,6 @@
 #include "../../memory_resource_mock.hpp"
 #include "../../tracking_memory_resource.hpp"
 #include "../../virtual_time_scheduler.hpp"
-#include "../multiplexer_mock.hpp"
 #include "media_mock.hpp"
 
 #include <canard.h>
@@ -81,7 +80,7 @@ protected:
         // but it's not possible due to CETL issue https://github.com/OpenCyphal/CETL/issues/119.
         const auto opt_local_node_id = cetl::optional<NodeId>{local_node_id};
 
-        auto maybe_transport = can::makeTransport(mr, mux_mock_, media_array, 16, opt_local_node_id);
+        auto maybe_transport = can::makeTransport(mr, media_array, 16, opt_local_node_id);
         EXPECT_THAT(maybe_transport, VariantWith<UniquePtr<can::ICanTransport>>(NotNull()));
         return cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
     }
@@ -91,7 +90,6 @@ protected:
     // NOLINTBEGIN
     libcyphal::VirtualTimeScheduler scheduler_{};
     TrackingMemoryResource          mr_;
-    StrictMock<MultiplexerMock>     mux_mock_{};
     StrictMock<can::MediaMock>      media_mock_{};
     // NOLINTEND
 };
@@ -187,7 +185,7 @@ TEST_F(TestCanSvcTxSessions, send_request_with_argument_error)
     // Make initially anonymous node transport.
     //
     std::array<can::IMedia*, 1> media_array{&media_mock_};
-    auto                        maybe_transport = can::makeTransport(mr_, mux_mock_, media_array, 2, {});
+    auto                        maybe_transport = can::makeTransport(mr_, media_array, 2, {});
     ASSERT_THAT(maybe_transport, VariantWith<UniquePtr<can::ICanTransport>>(NotNull()));
     auto transport = cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
 
@@ -319,7 +317,7 @@ TEST_F(TestCanSvcTxSessions, send_respose_with_argument_error)
     // Make initially anonymous node transport.
     //
     std::array<can::IMedia*, 1> media_array{&media_mock_};
-    auto                        maybe_transport = can::makeTransport(mr_, mux_mock_, media_array, 2, {});
+    auto                        maybe_transport = can::makeTransport(mr_, media_array, 2, {});
     ASSERT_THAT(maybe_transport, VariantWith<UniquePtr<can::ICanTransport>>(NotNull()));
     auto transport = cetl::get<UniquePtr<can::ICanTransport>>(std::move(maybe_transport));
 

--- a/test/unittest/transport/test_scattered_buffer.cpp
+++ b/test/unittest/transport/test_scattered_buffer.cpp
@@ -5,6 +5,7 @@
 
 #include <libcyphal/transport/scattered_buffer.hpp>
 
+#include <cetl/pf17/cetlpf.hpp>
 #include <cetl/rtti.hpp>
 
 #include <gmock/gmock.h>
@@ -12,7 +13,6 @@
 
 #include <array>
 #include <cstddef>
-#include <cstdint>
 #include <utility>
 
 namespace
@@ -36,7 +36,7 @@ public:
     MOCK_METHOD(void, deinit, (), (noexcept));  // NOLINT(bugprone-exception-escape)
 
     MOCK_METHOD(std::size_t, size, (), (const, noexcept, override));  // NOLINT(bugprone-exception-escape)
-    MOCK_METHOD(std::size_t, copy, (const std::size_t, void* const, const std::size_t), (const, override));
+    MOCK_METHOD(std::size_t, copy, (const std::size_t, cetl::byte* const, const std::size_t), (const, override));
 };
 class StorageWrapper final : public cetl::rtti_helper<StorageWrapperTypeIdType, ScatteredBuffer::IStorage>
 {
@@ -74,7 +74,7 @@ public:
         return (mock_ != nullptr) ? mock_->size() : 0;
     }
     std::size_t copy(const std::size_t offset_bytes,
-                     void* const       destination,
+                     cetl::byte* const destination,
                      const std::size_t length_bytes) const override
     {
         return (mock_ != nullptr) ? mock_->copy(offset_bytes, destination, length_bytes) : 0;
@@ -122,7 +122,7 @@ TEST(TestScatteredBuffer, move_ctor_assign_size)
 
 TEST(TestScatteredBuffer, copy_reset)
 {
-    std::array<std::uint8_t, 16> test_dst{};
+    std::array<cetl::byte, 16> test_dst{};
 
     StrictMock<StorageMock> storage_mock{};
     EXPECT_CALL(storage_mock, deinit()).Times(1);


### PR DESCRIPTION
No `CETL_NODISCARD` for the most of public api (issue #350), but private (aka `detail`) stuff stays under strict `[[nodiscard]]` policy for all non-`void` returning functions.

Also:
- Less `NOSONAR`-s by switching some internal `void*`-s → `cetl::byte*`-s.
- Eliminated `IMultiplexer` at CAN - no use of it; but will be at UDP.
- More docs for public api.
- Fixed Build Status and Sonar Cloud badges at `README.md`.