### PR TITLE
Remove None as a scheduling option

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "linux development environment for libcyphal",
-    "image": "ghcr.io/opencyphal/toolshed:ts22.4.7",
+    "image": "ghcr.io/opencyphal/toolshed:ts22.4.8",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/docs/examples/example_02_posix_udp_transport.cpp
+++ b/docs/examples/example_02_posix_udp_transport.cpp
@@ -73,7 +73,7 @@ protected:
         {
             local_node_id_ = static_cast<NodeId>(std::stoul(node_id_str));
         }
-        // Space separated list of interface addresses, like "vcan0 vcan1". Default is "vcan0".
+        // Space separated list of interface addresses, like "127.0.0.1 192.168.1.162". Default is "127.0.0.1".
         if (const auto* const iface_addresses_str = std::getenv("CYPHAL__UDP__IFACE"))
         {
             iface_addresses_ = CommonHelpers::splitInterfaceAddresses(iface_addresses_str);

--- a/docs/examples/example_03_linux_socketcan_transport.cpp
+++ b/docs/examples/example_03_linux_socketcan_transport.cpp
@@ -77,7 +77,7 @@ protected:
         {
             local_node_id_ = static_cast<NodeId>(std::stoul(node_id_str));
         }
-        // Space separated list of interface addresses, like "slcan0 slcan1". Default is "slcan0".
+        // Space separated list of interface addresses, like "slcan0 slcan1". Default is "vcan0".
         if (const auto* const iface_addresses_str = std::getenv("CYPHAL__CAN__IFACE"))
         {
             iface_addresses_ = CommonHelpers::splitInterfaceAddresses(iface_addresses_str);

--- a/docs/examples/platform/common_helpers.hpp
+++ b/docs/examples/platform/common_helpers.hpp
@@ -184,9 +184,7 @@ struct CommonHelpers
 
                     callback_             = executor.registerCallback([&](const auto now) { publish(now); });
                     constexpr auto period = std::chrono::seconds{uavcan::node::Heartbeat_1_0::MAX_PUBLICATION_PERIOD};
-                    const bool result = callback_.schedule(Callback::Schedule::Repeat{startup_time + period, period});
-                    (void) result;
-                    CETL_DEBUG_ASSERT(result, "Failed to schedule heartbeat callback.");
+                    callback_.schedule(Callback::Schedule::Repeat{startup_time + period, period});
                 }
             }
 

--- a/docs/examples/platform/linux/can/can_media.hpp
+++ b/docs/examples/platform/linux/can/can_media.hpp
@@ -176,19 +176,17 @@ private:
     }
 
     CETL_NODISCARD libcyphal::IExecutor::Callback::Any registerPushCallback(
-        libcyphal::IExecutor&                      executor,
         libcyphal::IExecutor::Callback::Function&& function) override
     {
         using HandleWritable = posix::IPosixExecutorExtension::WhenCondition::HandleWritable;
-        return registerCallbackWithCondition(executor, std::move(function), HandleWritable{socket_can_fd_});
+        return registerCallbackWithCondition(executor_, std::move(function), HandleWritable{socket_can_fd_});
     }
 
     CETL_NODISCARD libcyphal::IExecutor::Callback::Any registerPopCallback(
-        libcyphal::IExecutor&                      executor,
         libcyphal::IExecutor::Callback::Function&& function) override
     {
         using HandleReadable = posix::IPosixExecutorExtension::WhenCondition::HandleReadable;
-        return registerCallbackWithCondition(executor, std::move(function), HandleReadable{socket_can_fd_});
+        return registerCallbackWithCondition(executor_, std::move(function), HandleReadable{socket_can_fd_});
     }
 
     // MARK: Data members:

--- a/docs/examples/platform/posix/posix_platform_error.hpp
+++ b/docs/examples/platform/posix/posix_platform_error.hpp
@@ -49,17 +49,4 @@ private:
 }  // namespace platform
 }  // namespace example
 
-namespace cetl
-{
-
-// Just random id: 5D29D78C-3785-43A2-8D15-7FAF2C3881BC
-template <>
-constexpr type_id type_id_getter<example::platform::posix::PosixPlatformError>() noexcept
-{
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
-    return {0x5D, 0x29, 0xD7, 0x8C, 0x37, 0x85, 0x43, 0xA2, 0x8D, 0x15, 0x7F, 0xAF, 0x2C, 0x38, 0x81, 0xBC};
-}
-
-}  // namespace cetl
-
 #endif  // EXAMPLE_PLATFORM_POSIX_PLATFORM_ERROR_HPP_INCLUDED

--- a/docs/examples/platform/posix/posix_single_threaded_executor.hpp
+++ b/docs/examples/platform/posix/posix_single_threaded_executor.hpp
@@ -136,9 +136,7 @@ public:
                 {
                     if (auto* const cb_interface = callback_interfaces_[index])
                     {
-                        const bool result = cb_interface->schedule(Callback::Schedule::Once{now_time});
-                        (void) result;
-                        CETL_DEBUG_ASSERT(result, "Failed to schedule callback.");
+                        cb_interface->schedule(Callback::Schedule::Once{now_time});
                     }
                 }
             }

--- a/docs/examples/platform/posix/posix_single_threaded_executor.hpp
+++ b/docs/examples/platform/posix/posix_single_threaded_executor.hpp
@@ -44,7 +44,7 @@ public:
         : total_awaitables_{0}
         , awaitable_nodes_allocator_{&memory_resource}
         , poll_fds_{&memory_resource}
-        , callback_handles_{&memory_resource}
+        , callback_interfaces_{&memory_resource}
     {
     }
 
@@ -55,8 +55,8 @@ public:
 
     ~PosixSingleThreadedExecutor() override
     {
-        // Just in case release whatever awaitable nodes left, but properly used `Callback::Handle`-s
-        // (aka "handle must not outlive executor") should have removed them all.
+        // Just in case release whatever awaitable nodes left, but properly used `Callback::Interface`-s
+        // (see `onCallbackHandling`) should have removed them all.
         //
         CETL_DEBUG_ASSERT(awaitable_nodes_.empty(), "");
         awaitable_nodes_.traversePostOrder([this](auto& node) { destroyAwaitableNode(node); });
@@ -87,13 +87,13 @@ public:
         // so we can reuse them, and grow on demand (but never shrink).
         //
         poll_fds_.clear();
-        callback_handles_.clear();
+        callback_interfaces_.clear();
         awaitable_nodes_.traverseInOrder([this](AwaitableNode& node) {
             //
-            callback_handles_.push_back(node.handle());
+            callback_interfaces_.push_back(node.cb_interface());
             poll_fds_.push_back({node.fd(), static_cast<short int>(node.pollEvents()), 0});
         });
-        if ((total_awaitables_ != poll_fds_.size()) || (total_awaitables_ != callback_handles_.size()))
+        if ((total_awaitables_ != poll_fds_.size()) || (total_awaitables_ != callback_interfaces_.size()))
         {
             return libcyphal::transport::MemoryError{};
         }
@@ -134,8 +134,12 @@ public:
 
                 if (0 != (static_cast<PollEvents>(poll_fd.revents) & static_cast<PollEvents>(poll_fd.events)))
                 {
-                    const Callback::Handle cb_handle = callback_handles_[index];
-                    scheduleCallbackByHandle(cb_handle, Callback::Schedule::Once{now_time});
+                    if (auto* const cb_interface = callback_interfaces_[index])
+                    {
+                        const bool result = cb_interface->schedule(Callback::Schedule::Once{now_time});
+                        (void) result;
+                        CETL_DEBUG_ASSERT(result, "Failed to schedule callback.");
+                    }
                 }
             }
         }
@@ -153,49 +157,31 @@ public:
         poll_fds_.clear();
         poll_fds_.shrink_to_fit();
 
-        callback_handles_.clear();
-        callback_handles_.shrink_to_fit();
+        callback_interfaces_.clear();
+        callback_interfaces_.shrink_to_fit();
     }
 
 protected:
-    void onCallbackHandling(const Callback::Handle old_handle, const Callback::Handle new_handle) noexcept override
+    void onCallbackHandling(const CallbackHandling::Variant& event_var) override
     {
-        auto* const awaitable_node = awaitable_nodes_.search(  //
-            [old_handle](const AwaitableNode& node) {          // predicate
-                return node.compareByHandle(old_handle);
-            });
-        if (nullptr == awaitable_node)
-        {
-            return;
-        }
-
-        awaitable_nodes_.remove(awaitable_node);
-
-        if (new_handle)
-        {
-            awaitable_node->handle() = new_handle;
-            awaitable_nodes_.search(  //
-                [new_handle](const AwaitableNode& node) { return node.compareByHandle(new_handle); },
-                [awaitable_node]() { return awaitable_node; });
-        }
-        else
-        {
-            destroyAwaitableNode(*awaitable_node);
-        }
+        cetl::visit([this](const auto& event) { onCallbackHandlingImpl(event); }, event_var);
     }
 
     // MARK: - IPosixExecutorExtension
 
     bool scheduleCallbackWhen(Callback::Any& callback, const WhenCondition::Variant& when_condition) override
     {
-        const Callback::Handle cb_handle = callbackToHandle(callback);
+        Callback::Interface* const cb_interface = callback.getInterface();
 
         return cetl::visit(
-            [this, cb_handle](const auto& condition) {  //
-                return scheduleCallbackWhenImpl(cb_handle, condition);
+            [this, cb_interface](const auto& condition) {
+                //
+                return scheduleCallbackWhenImpl(cb_interface, condition);
             },
             when_condition);
     }
+
+    // MARK: - RTTI
 
     CETL_NODISCARD void* _cast_(const cetl::type_id& id) & noexcept override
     {
@@ -223,8 +209,8 @@ private:
     public:
         using Node::getChildNode;
 
-        explicit AwaitableNode(const Callback::Handle cb_handle)
-            : cb_handle_{cb_handle}
+        explicit AwaitableNode(Callback::Interface* const cb_interface)
+            : cb_interface_{cb_interface}
             , fd_{-1}
             , poll_events_{0}
         {
@@ -237,9 +223,9 @@ private:
         AwaitableNode& operator=(const AwaitableNode&)     = delete;
         AwaitableNode& operator=(AwaitableNode&&) noexcept = delete;
 
-        Callback::Handle& handle() noexcept
+        Callback::Interface*& cb_interface() noexcept
         {
-            return cb_handle_;
+            return cb_interface_;
         }
 
         int& fd() noexcept
@@ -252,38 +238,73 @@ private:
             return poll_events_;
         }
 
-        CETL_NODISCARD std::int8_t compareByHandle(const Callback::Handle cb_handle) const noexcept
+        CETL_NODISCARD std::int8_t compareByInterface(Callback::Interface* const cb_interface) const noexcept
         {
-            if (cb_handle == cb_handle_)
+            if (cb_interface == cb_interface_)
             {
                 return 0;
             }
-            return (cb_handle > cb_handle_) ? +1 : -1;
+            return (cb_interface > cb_interface_) ? +1 : -1;
         }
 
     private:
         // MARK: Data members:
 
-        Callback::Handle cb_handle_;
-        int              fd_;
-        PollEvents       poll_events_;
+        Callback::Interface* cb_interface_;
+        int                  fd_;
+        PollEvents           poll_events_;
 
     };  // AwaitableNode
 
-    CETL_NODISCARD AwaitableNode* ensureAwaitableNode(const Callback::Handle cb_handle)
+    void onCallbackHandlingImpl(const CallbackHandling::Moved& moved) noexcept
+    {
+        if (auto* const awaitable_node = awaitable_nodes_.search(  //
+                [&moved](const AwaitableNode& node) {              // predicate
+                    //
+                    return node.compareByInterface(moved.old_interface);
+                }))
+        {
+            awaitable_nodes_.remove(awaitable_node);
+            awaitable_node->cb_interface() = moved.new_interface;
+
+            awaitable_nodes_.search(                   //
+                [&moved](const AwaitableNode& node) {  // predicate
+                    //
+                    return node.compareByInterface(moved.new_interface);
+                },
+                [awaitable_node]() { return awaitable_node; });
+        }
+    }
+
+    void onCallbackHandlingImpl(const CallbackHandling::Removed& removed) noexcept
+    {
+        if (auto* const awaitable_node = awaitable_nodes_.search(  //
+                [&removed](const AwaitableNode& node) {            // predicate
+                    //
+                    return node.compareByInterface(removed.old_interface);
+                }))
+        {
+            awaitable_nodes_.remove(awaitable_node);
+            destroyAwaitableNode(*awaitable_node);
+        }
+    }
+
+    CETL_NODISCARD AwaitableNode* ensureAwaitableNode(Callback::Interface* const cb_interface)
     {
         const std::tuple<AwaitableNode*, bool> node_existing = awaitable_nodes_.search(  //
-            [cb_handle](const AwaitableNode& node) {                                     // predicate
-                return node.compareByHandle(cb_handle);
+            [cb_interface](const AwaitableNode& node) {                                  // predicate
+                //
+                return node.compareByInterface(cb_interface);
             },
-            [this, cb_handle]() {  // factory
-                return makeAwaitableNode(cb_handle);
+            [this, cb_interface]() {  // factory
+                //
+                return makeAwaitableNode(cb_interface);
             });
 
         return std::get<0>(node_existing);
     }
 
-    CETL_NODISCARD AwaitableNode* makeAwaitableNode(const Callback::Handle cb_handle)
+    CETL_NODISCARD AwaitableNode* makeAwaitableNode(Callback::Interface* const cb_interface)
     {
         // Stop allocations if we reach the maximum number of awaitables supported by `poll`.
         CETL_DEBUG_ASSERT(total_awaitables_ < std::numeric_limits<int>::max(), "");
@@ -295,7 +316,7 @@ private:
         AwaitableNode* const node = awaitable_nodes_allocator_.allocate(1);
         if (nullptr != node)
         {
-            awaitable_nodes_allocator_.construct(node, cb_handle);
+            awaitable_nodes_allocator_.construct(node, cb_interface);
         }
 
         ++total_awaitables_;
@@ -311,9 +332,9 @@ private:
         --total_awaitables_;
     }
 
-    bool scheduleCallbackWhenImpl(const Callback::Handle cb_handle, const WhenCondition::HandleReadable& readable)
+    bool scheduleCallbackWhenImpl(Callback::Interface* cb_interface, const WhenCondition::HandleReadable& readable)
     {
-        auto* const awaitable_node = ensureAwaitableNode(cb_handle);
+        auto* const awaitable_node = ensureAwaitableNode(cb_interface);
         if (nullptr == awaitable_node)
         {
             return false;
@@ -325,9 +346,9 @@ private:
         return true;
     }
 
-    bool scheduleCallbackWhenImpl(const Callback::Handle cb_handle, const WhenCondition::HandleWritable& writable)
+    bool scheduleCallbackWhenImpl(Callback::Interface* cb_interface, const WhenCondition::HandleWritable& writable)
     {
-        auto* const awaitable_node = ensureAwaitableNode(cb_handle);
+        auto* const awaitable_node = ensureAwaitableNode(cb_interface);
         if (nullptr == awaitable_node)
         {
             return false;
@@ -342,14 +363,14 @@ private:
     // MARK: - Data members:
 
     using PollFds = cetl::VariableLengthArray<pollfd, cetl::pmr::polymorphic_allocator<pollfd>>;
-    using CallbackHandles =
-        cetl::VariableLengthArray<Callback::Handle, cetl::pmr::polymorphic_allocator<Callback::Handle>>;
+    using CallbackInterfaces =
+        cetl::VariableLengthArray<Callback::Interface*, cetl::pmr::polymorphic_allocator<Callback::Interface*>>;
 
     std::size_t                                    total_awaitables_;
     cavl::Tree<AwaitableNode>                      awaitable_nodes_;
     libcyphal::detail::PmrAllocator<AwaitableNode> awaitable_nodes_allocator_;
     PollFds                                        poll_fds_;
-    CallbackHandles                                callback_handles_;
+    CallbackInterfaces                             callback_interfaces_;
 
 };  // PosixSingleThreadedExecutor
 

--- a/docs/examples/platform/posix/udp/udp.c
+++ b/docs/examples/platform/posix/udp/udp.c
@@ -262,39 +262,3 @@ uint32_t udpParseIfaceAddress(const char* const address)
     }
     return out;
 }
-
-int udpGetSocketOptionInt(const int fd, const int option)
-{
-    int res = -EINVAL;
-    if (fd >= 0)
-    {
-        int       value         = 0;
-        socklen_t option_length = sizeof(value);
-        if (getsockopt(fd, SOL_SOCKET, option, &value, &option_length) == 0)
-        {
-            res = value;
-        }
-        else
-        {
-            res = -errno;
-        }
-    }
-    return res;
-}
-
-int udpSetSocketOptionInt(const int fd, const int option, const int value)
-{
-    int res = -EINVAL;
-    if (fd >= 0)
-    {
-        if (setsockopt(fd, SOL_SOCKET, option, &value, sizeof(value)) == 0)
-        {
-            res = 0;
-        }
-        else
-        {
-            res = -errno;
-        }
-    }
-    return res;
-}

--- a/docs/examples/platform/posix/udp/udp.h
+++ b/docs/examples/platform/posix/udp/udp.h
@@ -113,9 +113,6 @@ int16_t udpWait(const uint64_t        timeout_usec,
 /// Returns zero if the address is not recognized.
 uint32_t udpParseIfaceAddress(const char* const address);
 
-int udpGetSocketOptionInt(const int fd, const int option);
-int udpSetSocketOptionInt(const int fd, const int option, const int value);
-
 #ifdef __cplusplus
 }
 #endif

--- a/docs/examples/platform/posix/udp/udp_media.hpp
+++ b/docs/examples/platform/posix/udp/udp_media.hpp
@@ -51,7 +51,7 @@ private:
 
     MakeTxSocketResult::Type makeTxSocket() override
     {
-        return UdpTxSocket::make(memory_, iface_address_);
+        return UdpTxSocket::make(memory_, executor_, iface_address_);
     }
 
     MakeRxSocketResult::Type makeRxSocket(const libcyphal::transport::udp::IpEndpoint& multicast_endpoint) override

--- a/include/libcyphal/executor.hpp
+++ b/include/libcyphal/executor.hpp
@@ -11,6 +11,7 @@
 #include <cetl/pf17/cetlpf.hpp>
 #include <cetl/pmr/function.hpp>
 #include <cetl/rtti.hpp>
+#include <cetl/unbounded_variant.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -19,33 +20,26 @@
 namespace libcyphal
 {
 
-// EBAF7312-5CFE-45F5-89FF-D9B9FE45F8EB
-using IExecutorTypeIdType = cetl::
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
-    type_id_type<0xEB, 0xAF, 0x73, 0x12, 0x5C, 0xFE, 0x45, 0xF5, 0x89, 0xFF, 0xD9, 0xB9, 0xFE, 0x45, 0xF8, 0xEB>;
-
 /// @brief Defines an abstract interface for a callback executor.
 ///
-class IExecutor : public cetl::rtti_helper<IExecutorTypeIdType>
+class IExecutor
 {
+    // EBAF7312-5CFE-45F5-89FF-D9B9FE45F8EB
+    // clang-format off
+    using TypeIdType = cetl::type_id_type<
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+        0xEB, 0xAF, 0x73, 0x12, 0x5C, 0xFE, 0x45, 0xF5, 0x89, 0xFF, 0xD9, 0xB9, 0xFE, 0x45, 0xF8, 0xEB>;
+    // clang-format on
+
 public:
     /// NOSONAR cpp:S4963 - we do directly handle callback resource here.
     ///
-    class Callback
+    struct Callback
     {
-    public:
         /// @brief Defines possible variants of callback schedules.
         ///
         struct Schedule
         {
-            /// @brief Defines schedule which will NOT execute callback function.
-            ///
-            /// Useful as a default value for a non-engaged callback schedule.
-            /// Also can be used to cancel previously scheduled callback.
-            ///
-            struct None
-            {};
-
             /// @brief Defines schedule which will execute callback function at the specified execution time once.
             ///
             struct Once
@@ -68,7 +62,7 @@ public:
                 Duration period;
             };
 
-            using Variant = cetl::variant<None, Once, Repeat>;
+            using Variant = cetl::variant<Once, Repeat>;
 
         };  // Schedule
 
@@ -77,6 +71,21 @@ public:
         /// Size is chosen arbitrary, but it should be enough to store any lambda or function pointer.
         ///
         static constexpr std::size_t FunctionMaxSize = sizeof(void*) * 8;
+
+        /// @brief Defines type of callback `Function` single argument.
+        ///
+        /// References to instances of this type are passed to the function during callback execution.
+        /// The following holds: `exec_time` <= `approx_now` <= `Executor::now()`.
+        ///
+        struct Arg
+        {
+            /// Time when the callback was scheduled to be executed.
+            TimePoint exec_time;
+
+            /// An approximation of the current time.
+            TimePoint approx_now;
+
+        };  // Arg
 
         /// @brief Defines callback function signature.
         ///
@@ -87,32 +96,124 @@ public:
         ///                 Depending on executor load, the actual time could be a bit later
         ///                 than it was originally scheduled as desired execution time.
         ///
-        using Function = cetl::pmr::function<void(const TimePoint now_time), FunctionMaxSize>;
+        using Function = cetl::pmr::function<void(const Arg& arg), FunctionMaxSize>;
 
         /// @brief Defines maximum size of callback implementation.
         ///
         /// Size is chosen arbitrary, but it should be enough to store any callback implementation.
         ///
-        static constexpr std::size_t MaxSize = (sizeof(void*) * 10) + sizeof(Function);
+        static constexpr std::size_t MaxSize = (sizeof(void*) * 12) + sizeof(Function);
+
+        class Interface
+        {
+            // 5E16E6BC-C7EB-42EC-8A98-06189C2F0349
+            // clang-format off
+            using TypeIdType = cetl::type_id_type<
+                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+                0x5E, 0x16, 0xE6, 0xBC, 0xC7, 0xEB, 0x42, 0xEC, 0x8A, 0x98, 0x06, 0x18, 0x9C, 0x2F, 0x03, 0x49>;
+            // clang-format on
+
+        public:
+            Interface(const Interface&)                = delete;
+            Interface(Interface&&) noexcept            = delete;
+            Interface& operator=(const Interface&)     = delete;
+            Interface& operator=(Interface&&) noexcept = delete;
+
+            /// @brief Schedules previously registered callback for execution according to a desired schedule.
+            ///
+            /// Actual execution of the callback's function will be done later (not from context of this method),
+            /// when desired time comes and executor is ready to execute callbacks. It's ok to schedule the same
+            /// callback multiple times even before it was executed - it will be rescheduled, and then executed
+            /// according to the last setup.
+            ///
+            /// @param schedule Contains specifics of how exactly callback will be scheduled.
+            /// @return `true` if scheduling was successful, `false` otherwise (b/c callback has been reset).
+            ///
+            CETL_NODISCARD virtual bool schedule(const Schedule::Variant& schedule) = 0;
+
+            // MARK: RTTI
+
+            static constexpr cetl::type_id _get_type_id_() noexcept
+            {
+                return cetl::type_id_type_value<TypeIdType>();
+            }
+
+            // No Sonar `cpp:S5008` and `cpp:S5356` b/c they are unavoidable - RTTI integration.
+            CETL_NODISCARD void* _cast_(const cetl::type_id& id) & noexcept  // NOSONAR cpp:S5008
+            {
+                return (id == _get_type_id_()) ? this : nullptr;  // NOSONAR cpp:S5356
+            }
+
+            // No Sonar `cpp:S5008` and `cpp:S5356` b/c they are unavoidable - RTTI integration.
+            CETL_NODISCARD const void* _cast_(const cetl::type_id& id) const& noexcept  // NOSONAR cpp:S5008
+            {
+                return (id == _get_type_id_()) ? this : nullptr;  // NOSONAR cpp:S5356
+            }
+
+        protected:
+            Interface()  = default;
+            ~Interface() = default;
+
+        };  // Interface
 
         /// @brief Defines type-erased callback which is capable to store some internal implementation.
         ///
-        /// It is supposed to be used to hide callback implementation,
-        /// and to be passed to the executor for scheduling.
+        /// It is expected that the internal implementation supports `Callback::Interface` (RTTI-cast-able to).
+        ///
+        /// It is supposed to be used to hide callback implementation.
         /// It also manages lifetime and ownership of the callback registration, so it's movable but not copyable.
         ///
-        using Any = cetl::unbounded_variant<MaxSize, false /* Copyable */, true /* Movable */>;
+        /// No Sonar cpp:S110 b/c `unbounded_variant` has initial
+        /// inheritance hierarchy depth of 5 (b/c it's policy-based implementation).
+        ///
+        class Any final  // NOSONAR cpp:S110
+            : public cetl::unbounded_variant<MaxSize, false /* Copyable */, true /* Movable */>
+        {
+        public:
+            using unbounded_variant::unbounded_variant;
 
-        /// @brief Defines opaque handle to a registered callback.
-        ///
-        /// It is supposed to be used internally (by derived executors)
-        /// to identify/reference the callback in the executor.
-        ///
-        using Handle = std::uintptr_t;
+            explicit operator bool() const noexcept
+            {
+                return has_value();
+            }
+
+            /// @breif Gets the internal implementation interface of the callback.
+            ///
+            Interface* getInterface() noexcept
+            {
+                if (!has_value())
+                {
+                    return nullptr;
+                }
+
+                auto* const interface = cetl::get_if<Interface>(this);
+                CETL_DEBUG_ASSERT(interface != nullptr,
+                                  "Internal implementation must be rtti-cast-able to `Callback::Interface`");
+                return interface;
+            }
+
+            /// @brief Schedules previously registered callback for execution according to a desired schedule.
+            ///
+            /// Actual execution of the callback's function will be done later (not from context of this method),
+            /// when desired time comes and executor is ready to execute callbacks. It's ok to schedule the same
+            /// callback multiple times even before it was executed - it will be rescheduled, and then executed
+            /// according to the last setup.
+            ///
+            /// @param schedule Contains specifics of how exactly callback will be scheduled.
+            /// @return `true` if scheduling was successful, `false` otherwise (b/c callback had been reset).
+            ///
+            CETL_NODISCARD bool schedule(const Schedule::Variant& schedule)
+            {
+                if (auto* const interface = getInterface())
+                {
+                    return interface->schedule(schedule);
+                }
+                return false;
+            }
+
+        };  // Any
 
     };  // Callback
-
-    ~IExecutor() override = default;
 
     IExecutor(const IExecutor&)                = delete;
     IExecutor(IExecutor&&) noexcept            = delete;
@@ -129,26 +230,33 @@ public:
     /// For scheduling, the very same executor instance must be used; otherwise, undefined behavior (UB).
     ///
     /// @param function The function to be called when the callback is executed.
-    /// @return Type-erased instance of the registered callback. Instance must not outlive the executor,
-    ///         and must be used only with the same executor; otherwise undefined behavior.
+    /// @return Type-erased instance of the registered callback.
+    ///         Instance must not outlive the executor; otherwise undefined behavior.
     ///
     CETL_NODISCARD virtual Callback::Any registerCallback(Callback::Function&& function) = 0;
 
-    /// @brief Schedules previously registered callback for execution according to a desired schedule.
-    ///
-    /// Actual execution of the callback's function will be done later (not from context of this method), when desired
-    /// time comes and executor is ready to execute callbacks. It's ok to schedule the same callback multiple times
-    /// even before it was executed - it will be rescheduled, and then executed according to the last setup.
-    ///
-    /// @param callback The callback instance (registered at this executor) to be scheduled.
-    ///                 There will be no scheduling if callback is not registered yet
-    ///                 (in its initial default value), or has been reset already.
-    /// @param schedule Contains specifics of how exactly callback will be scheduled (like once, repeatedly etc.).
-    ///
-    virtual void scheduleCallback(Callback::Any& callback, const Callback::Schedule::Variant& schedule) = 0;
+    // MARK: RTTI
+
+    static constexpr cetl::type_id _get_type_id_() noexcept
+    {
+        return cetl::type_id_type_value<TypeIdType>();
+    }
+
+    // No Sonar `cpp:S5008` and `cpp:S5356` b/c they are unavoidable - RTTI integration.
+    CETL_NODISCARD virtual void* _cast_(const cetl::type_id& id) & noexcept  // NOSONAR cpp:S5008
+    {
+        return (id == _get_type_id_()) ? this : nullptr;  // NOSONAR cpp:S5356
+    }
+
+    // No Sonar `cpp:S5008` and `cpp:S5356` b/c they are unavoidable - RTTI integration.
+    CETL_NODISCARD virtual const void* _cast_(const cetl::type_id& id) const& noexcept  // NOSONAR cpp:S5008
+    {
+        return (id == _get_type_id_()) ? this : nullptr;  // NOSONAR cpp:S5356
+    }
 
 protected:
-    IExecutor() = default;
+    IExecutor()  = default;
+    ~IExecutor() = default;
 
 };  // IExecutor
 

--- a/include/libcyphal/executor.hpp
+++ b/include/libcyphal/executor.hpp
@@ -114,8 +114,8 @@ public:
             // clang-format on
 
         public:
-                       Interface(const Interface&)     = delete;
-                       Interface(Interface&&) noexcept = delete;
+            Interface(const Interface&)                = delete;
+            Interface(Interface&&) noexcept            = delete;
             Interface& operator=(const Interface&)     = delete;
             Interface& operator=(Interface&&) noexcept = delete;
 
@@ -151,7 +151,7 @@ public:
             }
 
         protected:
-             Interface() = default;
+            Interface()  = default;
             ~Interface() = default;
 
         };  // Interface
@@ -215,8 +215,8 @@ public:
 
     };  // Callback
 
-               IExecutor(const IExecutor&)     = delete;
-               IExecutor(IExecutor&&) noexcept = delete;
+    IExecutor(const IExecutor&)                = delete;
+    IExecutor(IExecutor&&) noexcept            = delete;
     IExecutor& operator=(const IExecutor&)     = delete;
     IExecutor& operator=(IExecutor&&) noexcept = delete;
 
@@ -255,7 +255,7 @@ public:
     }
 
 protected:
-     IExecutor() = default;
+    IExecutor()  = default;
     ~IExecutor() = default;
 
 };  // IExecutor

--- a/include/libcyphal/executor.hpp
+++ b/include/libcyphal/executor.hpp
@@ -129,7 +129,7 @@ public:
             /// @param schedule Contains specifics of how exactly callback will be scheduled.
             /// @return `true` if scheduling was successful, `false` otherwise (b/c callback has been reset).
             ///
-            CETL_NODISCARD virtual bool schedule(const Schedule::Variant& schedule) = 0;
+            virtual bool schedule(const Schedule::Variant& schedule) = 0;
 
             // MARK: RTTI
 
@@ -202,7 +202,7 @@ public:
             /// @param schedule Contains specifics of how exactly callback will be scheduled.
             /// @return `true` if scheduling was successful, `false` otherwise (b/c callback had been reset).
             ///
-            CETL_NODISCARD bool schedule(const Schedule::Variant& schedule)
+            bool schedule(const Schedule::Variant& schedule)
             {
                 if (auto* const interface = getInterface())
                 {

--- a/include/libcyphal/executor.hpp
+++ b/include/libcyphal/executor.hpp
@@ -32,7 +32,7 @@ class IExecutor
     // clang-format on
 
 public:
-    /// NOSONAR cpp:S4963 - we do directly handle callback resource here.
+    /// @brief Defines umbrella type for everything callback related.
     ///
     struct Callback
     {
@@ -114,8 +114,8 @@ public:
             // clang-format on
 
         public:
-            Interface(const Interface&)                = delete;
-            Interface(Interface&&) noexcept            = delete;
+                       Interface(const Interface&)     = delete;
+                       Interface(Interface&&) noexcept = delete;
             Interface& operator=(const Interface&)     = delete;
             Interface& operator=(Interface&&) noexcept = delete;
 
@@ -151,7 +151,7 @@ public:
             }
 
         protected:
-            Interface()  = default;
+             Interface() = default;
             ~Interface() = default;
 
         };  // Interface
@@ -215,8 +215,8 @@ public:
 
     };  // Callback
 
-    IExecutor(const IExecutor&)                = delete;
-    IExecutor(IExecutor&&) noexcept            = delete;
+               IExecutor(const IExecutor&)     = delete;
+               IExecutor(IExecutor&&) noexcept = delete;
     IExecutor& operator=(const IExecutor&)     = delete;
     IExecutor& operator=(IExecutor&&) noexcept = delete;
 
@@ -255,7 +255,7 @@ public:
     }
 
 protected:
-    IExecutor()  = default;
+     IExecutor() = default;
     ~IExecutor() = default;
 
 };  // IExecutor

--- a/include/libcyphal/platform/single_threaded_executor.hpp
+++ b/include/libcyphal/platform/single_threaded_executor.hpp
@@ -33,13 +33,13 @@ namespace platform
 class SingleThreadedExecutor : public IExecutor
 {
 public:
-             SingleThreadedExecutor() = default;
+    SingleThreadedExecutor()          = default;
     virtual ~SingleThreadedExecutor() = default;
 
-                            SingleThreadedExecutor(const SingleThreadedExecutor&)     = delete;
-                            SingleThreadedExecutor(SingleThreadedExecutor&&) noexcept = delete;
-    SingleThreadedExecutor& operator=(const SingleThreadedExecutor&)                  = delete;
-    SingleThreadedExecutor& operator=(SingleThreadedExecutor&&) noexcept              = delete;
+    SingleThreadedExecutor(const SingleThreadedExecutor&)                = delete;
+    SingleThreadedExecutor(SingleThreadedExecutor&&) noexcept            = delete;
+    SingleThreadedExecutor& operator=(const SingleThreadedExecutor&)     = delete;
+    SingleThreadedExecutor& operator=(SingleThreadedExecutor&&) noexcept = delete;
 
     struct SpinResult
     {
@@ -210,7 +210,7 @@ private:
             executor_.onCallbackHandling(CallbackHandling::Moved{&other, this});
         }
 
-                      CallbackNode(const CallbackNode&)        = delete;
+        CallbackNode(const CallbackNode&)                      = delete;
         CallbackNode& operator=(const CallbackNode&)           = delete;
         CallbackNode& operator=(CallbackNode&& other) noexcept = delete;
 

--- a/include/libcyphal/platform/single_threaded_executor.hpp
+++ b/include/libcyphal/platform/single_threaded_executor.hpp
@@ -248,6 +248,8 @@ private:
 
         CETL_NODISCARD bool schedule(const Callback::Schedule::Variant& schedule) override
         {
+            CETL_DEBUG_ASSERT(isLinked(), "");
+
             schedule_ = schedule;
             executor_.adjustNextExecTimeOf(*this, [this, &schedule](auto&) {
                 //

--- a/include/libcyphal/platform/single_threaded_executor.hpp
+++ b/include/libcyphal/platform/single_threaded_executor.hpp
@@ -33,13 +33,13 @@ namespace platform
 class SingleThreadedExecutor : public IExecutor
 {
 public:
-    SingleThreadedExecutor()          = default;
+             SingleThreadedExecutor() = default;
     virtual ~SingleThreadedExecutor() = default;
 
-    SingleThreadedExecutor(const SingleThreadedExecutor&)                = delete;
-    SingleThreadedExecutor(SingleThreadedExecutor&&) noexcept            = delete;
-    SingleThreadedExecutor& operator=(const SingleThreadedExecutor&)     = delete;
-    SingleThreadedExecutor& operator=(SingleThreadedExecutor&&) noexcept = delete;
+                            SingleThreadedExecutor(const SingleThreadedExecutor&)     = delete;
+                            SingleThreadedExecutor(SingleThreadedExecutor&&) noexcept = delete;
+    SingleThreadedExecutor& operator=(const SingleThreadedExecutor&)                  = delete;
+    SingleThreadedExecutor& operator=(SingleThreadedExecutor&&) noexcept              = delete;
 
     struct SpinResult
     {
@@ -195,8 +195,8 @@ private:
         {
             if (isLinked())
             {
-                executor().callback_nodes_.remove(this);
-                executor().onCallbackHandling(CallbackHandling::Removed{this});
+                executor_.callback_nodes_.remove(this);
+                executor_.onCallbackHandling(CallbackHandling::Removed{this});
             }
         };
 
@@ -207,10 +207,10 @@ private:
             , next_exec_time_{other.next_exec_time_}
             , schedule_{other.schedule_}
         {
-            executor().onCallbackHandling(CallbackHandling::Moved{&other, this});
+            executor_.onCallbackHandling(CallbackHandling::Moved{&other, this});
         }
 
-        CallbackNode(const CallbackNode&)                      = delete;
+                      CallbackNode(const CallbackNode&)        = delete;
         CallbackNode& operator=(const CallbackNode&)           = delete;
         CallbackNode& operator=(CallbackNode&& other) noexcept = delete;
 
@@ -244,17 +244,12 @@ private:
         }
 
     private:
-        SingleThreadedExecutor& executor() const noexcept
-        {
-            return executor_.get();
-        }
-
         // MARK: Callback::Interface
 
         CETL_NODISCARD bool schedule(const Callback::Schedule::Variant& schedule) override
         {
             schedule_ = schedule;
-            executor().adjustNextExecTimeOf(*this, [this, &schedule](auto&) {
+            executor_.adjustNextExecTimeOf(*this, [this, &schedule](auto&) {
                 //
                 next_exec_time_ = cetl::visit(  //
                     cetl::make_overloaded(      //
@@ -267,10 +262,10 @@ private:
 
         // MARK: Data members:
 
-        std::reference_wrapper<SingleThreadedExecutor> executor_;
-        Callback::Function                             function_;
-        TimePoint                                      next_exec_time_;
-        cetl::optional<Callback::Schedule::Variant>    schedule_;
+        SingleThreadedExecutor&                     executor_;
+        Callback::Function                          function_;
+        TimePoint                                   next_exec_time_;
+        cetl::optional<Callback::Schedule::Variant> schedule_;
 
     };  // CallbackNode
 

--- a/include/libcyphal/transport/can/can_transport_impl.hpp
+++ b/include/libcyphal/transport/can/can_transport_impl.hpp
@@ -163,10 +163,10 @@ public:
         scheduleConfigOfFilters();
     }
 
-                   TransportImpl(const TransportImpl&)     = delete;
-                   TransportImpl(TransportImpl&&) noexcept = delete;
-    TransportImpl& operator=(const TransportImpl&)         = delete;
-    TransportImpl& operator=(TransportImpl&&) noexcept     = delete;
+    TransportImpl(const TransportImpl&)                = delete;
+    TransportImpl(TransportImpl&&) noexcept            = delete;
+    TransportImpl& operator=(const TransportImpl&)     = delete;
+    TransportImpl& operator=(TransportImpl&&) noexcept = delete;
 
     ~TransportImpl()
     {

--- a/include/libcyphal/transport/can/can_transport_impl.hpp
+++ b/include/libcyphal/transport/can/can_transport_impl.hpp
@@ -231,9 +231,7 @@ private:
         //
         if (total_svc_rx_ports_ > 0)
         {
-            const bool result = configure_filters_callback_.schedule(Callback::Schedule::Once{executor_.now()});
-            (void) result;
-            CETL_DEBUG_ASSERT(result, "Failed to schedule filter configuration.");
+            configure_filters_callback_.schedule(Callback::Schedule::Once{executor_.now()});
         }
 
         return cetl::nullopt;
@@ -365,9 +363,7 @@ private:
             });
         }
 
-        const bool result = configure_filters_callback_.schedule(Callback::Schedule::Once{executor_.now()});
-        (void) result;
-        CETL_DEBUG_ASSERT(result, "Failed to schedule filter configuration.");
+        configure_filters_callback_.schedule(Callback::Schedule::Once{executor_.now()});
     }
 
     // MARK: Privates:

--- a/include/libcyphal/transport/can/can_transport_impl.hpp
+++ b/include/libcyphal/transport/can/can_transport_impl.hpp
@@ -231,7 +231,9 @@ private:
         //
         if (total_svc_rx_ports_ > 0)
         {
-            configure_filters_callback_.schedule(Callback::Schedule::Once{executor_.now()});
+            const bool result = configure_filters_callback_.schedule(Callback::Schedule::Once{executor_.now()});
+            (void) result;
+            CETL_DEBUG_ASSERT(result, "Unexpected failure to schedule filter configuration.");
         }
 
         return cetl::nullopt;
@@ -363,7 +365,9 @@ private:
             });
         }
 
-        configure_filters_callback_.schedule(Callback::Schedule::Once{executor_.now()});
+        const bool result = configure_filters_callback_.schedule(Callback::Schedule::Once{executor_.now()});
+        (void) result;
+        CETL_DEBUG_ASSERT(result, "Unexpected failure to schedule filter configuration.");
     }
 
     // MARK: Privates:

--- a/include/libcyphal/transport/can/can_transport_impl.hpp
+++ b/include/libcyphal/transport/can/can_transport_impl.hpp
@@ -163,10 +163,10 @@ public:
         scheduleConfigOfFilters();
     }
 
-    TransportImpl(const TransportImpl&)                = delete;
-    TransportImpl(TransportImpl&&) noexcept            = delete;
-    TransportImpl& operator=(const TransportImpl&)     = delete;
-    TransportImpl& operator=(TransportImpl&&) noexcept = delete;
+                   TransportImpl(const TransportImpl&)     = delete;
+                   TransportImpl(TransportImpl&&) noexcept = delete;
+    TransportImpl& operator=(const TransportImpl&)         = delete;
+    TransportImpl& operator=(TransportImpl&&) noexcept     = delete;
 
     ~TransportImpl()
     {
@@ -337,7 +337,7 @@ private:
             }
 
             // No need to try to push next frame when previous one hasn't finished yet.
-            if (!media.tx_callback().has_value())
+            if (!media.tx_callback())
             {
                 pushNextFrameToMedia(media);
             }
@@ -357,9 +357,10 @@ private:
 
     void scheduleConfigOfFilters()
     {
-        if (!configure_filters_callback_.has_value())
+        if (!configure_filters_callback_)
         {
-            configure_filters_callback_ = executor_.registerCallback([this](const auto&) {  //
+            configure_filters_callback_ = executor_.registerCallback([this](const auto&) {
+                //
                 configureMediaFilters();
             });
         }
@@ -433,7 +434,7 @@ private:
 
         for (Media& media : media_array_)
         {
-            if (!media.rx_callback().has_value())
+            if (!media.rx_callback())
             {
                 media.rx_callback() = media.interface().registerPopCallback([this, &media](const auto&) {  //
                     //
@@ -598,7 +599,7 @@ private:
                 // If needed schedule (recursively!) next frame to push.
                 // Already existing callback will be called by executor when media TX is ready to push more.
                 //
-                if (!media.tx_callback().has_value())
+                if (!media.tx_callback())
                 {
                     media.tx_callback() = media.interface().registerPushCallback([this, &media](const auto&) {
                         //

--- a/include/libcyphal/transport/can/delegate.hpp
+++ b/include/libcyphal/transport/can/delegate.hpp
@@ -42,18 +42,12 @@ namespace detail
 ///
 class TransportDelegate
 {
-    // 1141F5C0-2E61-44BF-9F0E-FA1C518CD517
-    using CanardMemoryTypeIdType = cetl::
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
-        type_id_type<0x11, 0x41, 0xF5, 0xC0, 0x2E, 0x61, 0x44, 0xBF, 0x9F, 0x0E, 0xFA, 0x1C, 0x51, 0x8C, 0xD5, 0x17>;
-
 public:
     /// @brief RAII class to manage memory allocated by Canard library.
     ///
     /// NOSONAR cpp:S4963 for below `class CanardMemory` - we do directly handle resources here.
     ///
-    class CanardMemory final  // NOSONAR cpp:S4963
-        : public cetl::rtti_helper<CanardMemoryTypeIdType, ScatteredBuffer::IStorage>
+    class CanardMemory final : public ScatteredBuffer::IStorage  // NOSONAR cpp:S4963
     {
     public:
         CanardMemory(TransportDelegate& delegate, cetl::byte* const buffer, const std::size_t payload_size)
@@ -70,7 +64,7 @@ public:
         }
         CanardMemory(const CanardMemory&) = delete;
 
-        ~CanardMemory() override
+        ~CanardMemory()
         {
             if (buffer_ != nullptr)
             {

--- a/include/libcyphal/transport/can/media.hpp
+++ b/include/libcyphal/transport/can/media.hpp
@@ -112,33 +112,29 @@ public:
 
     /// @brief Registers "ready to push" callback function at a given executor.
     ///
-    /// The callback will be called by the executor when this socket will be ready to accept more (MTU-worth) data.
+    /// The callback will be called by an executor when this socket will be ready to accept more (MTU-worth) data.
     ///
     /// For example, Linux socketcan implementation may pass its OS handle to the executor implementation,
     /// and executor will use `::poll` POSIX api & `POLLOUT` event to schedule this callback for execution.
     ///
-    /// @param executor The executor to register the callback at.
     /// @param function The function to be called when CAN media became "ready to push".
-    /// @return Type-erased instance of the registered callback. Instance must not outlive the executor,
-    ///         and must be used only with the same executor; otherwise undefined behavior.
+    /// @return Type-erased instance of the registered callback.
+    ///         Instance must not outlive the executor; otherwise undefined behavior.
     ///
-    CETL_NODISCARD virtual IExecutor::Callback::Any registerPushCallback(IExecutor&                      executor,
-                                                                         IExecutor::Callback::Function&& function) = 0;
+    CETL_NODISCARD virtual IExecutor::Callback::Any registerPushCallback(IExecutor::Callback::Function&& function) = 0;
 
     /// @brief Registers "ready to pop" callback function at a given executor.
     ///
-    /// The callback will be called by the executor when this socket will be ready to be read (MTU-worth data).
+    /// The callback will be called by an executor when this socket will be ready to be read (MTU-worth data).
     ///
     /// For example, Linux socketcan implementation may pass its OS handle to the executor implementation,
     /// and executor will use `::poll` POSIX api & `POLLIN` event to schedule this callback for execution.
     ///
-    /// @param executor The executor to register the callback at.
     /// @param function The function to be called when CAN media became "ready to pop".
-    /// @return Type-erased instance of the registered callback. Instance must not outlive the executor,
-    ///         and must be used only with the same executor; otherwise undefined behavior.
+    /// @return Type-erased instance of the registered callback.
+    ///         Instance must not outlive the executor; otherwise undefined behavior.
     ///
-    CETL_NODISCARD virtual IExecutor::Callback::Any registerPopCallback(IExecutor&                      executor,
-                                                                        IExecutor::Callback::Function&& function) = 0;
+    CETL_NODISCARD virtual IExecutor::Callback::Any registerPopCallback(IExecutor::Callback::Function&& function) = 0;
 
 protected:
     IMedia()  = default;

--- a/include/libcyphal/transport/errors.hpp
+++ b/include/libcyphal/transport/errors.hpp
@@ -38,10 +38,24 @@ struct CapacityError final
 ///
 class IPlatformError
 {
+    // C6271889-BCF8-43A9-8D79-FA64FC3EFD93
+    // clang-format off
+    using TypeIdType = cetl::type_id_type<
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+        0xC6, 0x27, 0x18, 0x89, 0xBC, 0xF8, 0x43, 0xA9, 0x8D, 0x79, 0xFA, 0x64, 0xFC, 0x3E, 0xFD, 0x93>;
+    // clang-format on
+
 public:
     /// Gets platform-specific error code.
     ///
     virtual std::uint32_t code() const noexcept = 0;
+
+    // MARK: RTTI
+
+    static constexpr cetl::type_id _get_type_id_() noexcept
+    {
+        return cetl::type_id_type_value<TypeIdType>();
+    }
 
 protected:
     IPlatformError()                                     = default;

--- a/include/libcyphal/transport/scattered_buffer.hpp
+++ b/include/libcyphal/transport/scattered_buffer.hpp
@@ -26,11 +26,6 @@ namespace transport
 ///
 class ScatteredBuffer final  // NOSONAR : cpp:S4963 - we do directly handle resources here.
 {
-    // 91C1B109-F90E-45BE-95CF-6ED02AC3FFAA
-    using IStorageTypeIdType = cetl::
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
-        type_id_type<0x91, 0xC1, 0xB1, 0x09, 0xF9, 0x0E, 0x45, 0xBE, 0x95, 0xCF, 0x6E, 0xD0, 0x2A, 0xC3, 0xFF, 0xAA>;
-
 public:
     /// @brief Defines maximum size (aka footprint) of the storage variant.
     ///
@@ -40,11 +35,16 @@ public:
     ///
     /// @see ScatteredBuffer::ScatteredBuffer(AnyStorage&& any_storage)
     ///
-    class IStorage : public cetl::rtti_helper<IStorageTypeIdType>
+    class IStorage
     {
-    public:
-        ~IStorage() override = default;
+        // 91C1B109-F90E-45BE-95CF-6ED02AC3FFAA
+        // clang-format off
+        using TypeIdType = cetl::type_id_type<
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+            0x91, 0xC1, 0xB1, 0x09, 0xF9, 0x0E, 0x45, 0xBE, 0x95, 0xCF, 0x6E, 0xD0, 0x2A, 0xC3, 0xFF, 0xAA>;
+        // clang-format on
 
+    public:
         // No copying, but move only!
         IStorage(const IStorage&)            = delete;
         IStorage& operator=(const IStorage&) = delete;
@@ -70,8 +70,28 @@ public:
                                  cetl::byte* const destination,
                                  const std::size_t length_bytes) const = 0;
 
+        // MARK: RTTI
+
+        static constexpr cetl::type_id _get_type_id_() noexcept
+        {
+            return cetl::type_id_type_value<TypeIdType>();
+        }
+
+        // No Sonar `cpp:S5008` and `cpp:S5356` b/c they are unavoidable - RTTI integration.
+        CETL_NODISCARD void* _cast_(const cetl::type_id& id) & noexcept  // NOSONAR cpp:S5008
+        {
+            return (id == _get_type_id_()) ? this : nullptr;  // NOSONAR cpp:S5356
+        }
+
+        // No Sonar `cpp:S5008` and `cpp:S5356` b/c they are unavoidable - RTTI integration.
+        CETL_NODISCARD const void* _cast_(const cetl::type_id& id) const& noexcept  // NOSONAR cpp:S5008
+        {
+            return (id == _get_type_id_()) ? this : nullptr;  // NOSONAR cpp:S5356
+        }
+
     protected:
         IStorage()                               = default;
+        ~IStorage()                              = default;
         IStorage(IStorage&&) noexcept            = default;
         IStorage& operator=(IStorage&&) noexcept = default;
 

--- a/include/libcyphal/transport/udp/delegate.hpp
+++ b/include/libcyphal/transport/udp/delegate.hpp
@@ -76,18 +76,12 @@ struct AnyUdpardTxMetadata
 ///
 class TransportDelegate
 {
-    // FD977E25-CD36-48C5-B02E-B31420DCFF3B
-    using UdpardMemoryTypeIdType = cetl::
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
-        type_id_type<0xFD, 0x97, 0x7E, 0x25, 0xCD, 0x36, 0x48, 0xC5, 0xB0, 0x2E, 0xB3, 0x14, 0x20, 0xDC, 0xFF, 0x3B>;
-
 public:
     /// @brief RAII class to manage memory allocated by Udpard library.
     ///
     /// NOSONAR cpp:S4963 for below `class UdpardMemory` - we do directly handle resources here.
     ///
-    class UdpardMemory final  // NOSONAR cpp:S4963
-        : public cetl::rtti_helper<UdpardMemoryTypeIdType, ScatteredBuffer::IStorage>
+    class UdpardMemory final : public ScatteredBuffer::IStorage  // NOSONAR cpp:S4963
     {
     public:
         UdpardMemory(TransportDelegate& delegate, UdpardRxTransfer& transfer)
@@ -102,13 +96,13 @@ public:
             , payload_{std::exchange(other.payload_, {})}
         {
         }
-        UdpardMemory(const UdpardMemory&) = delete;
 
-        ~UdpardMemory() override
+        ~UdpardMemory()
         {
             ::udpardRxFragmentFree(payload_, delegate_.memoryResources().fragment, delegate_.memoryResources().payload);
         }
 
+        UdpardMemory(const UdpardMemory&)                = delete;
         UdpardMemory& operator=(const UdpardMemory&)     = delete;
         UdpardMemory& operator=(UdpardMemory&&) noexcept = delete;
 

--- a/include/libcyphal/transport/udp/tx_rx_sockets.hpp
+++ b/include/libcyphal/transport/udp/tx_rx_sockets.hpp
@@ -98,18 +98,16 @@ public:
 
     /// @brief Registers "ready to send" callback function at a given executor.
     ///
-    /// The callback will be called by the executor when this socket will be ready to accept more (MTU-worth) data.
+    /// The callback will be called by an executor when this socket will be ready to accept more (MTU-worth) data.
     ///
     /// For example, POSIX socket implementation may pass its OS handle to the executor implementation,
     /// and executor will use `::poll` POSIX api & `POLLOUT` event to schedule this callback for execution.
     ///
-    /// @param executor The executor to register the callback at.
     /// @param function The function to be called when TX socket became "ready to send".
-    /// @return Type-erased instance of the registered callback. Instance must not outlive the executor,
-    ///         and must be used only with the same executor; otherwise undefined behavior.
+    /// @return Type-erased instance of the registered callback.
+    ///         Instance must not outlive the executor; otherwise undefined behavior.
     ///
-    CETL_NODISCARD virtual IExecutor::Callback::Any registerCallback(IExecutor&                      executor,
-                                                                     IExecutor::Callback::Function&& function) = 0;
+    CETL_NODISCARD virtual IExecutor::Callback::Any registerCallback(IExecutor::Callback::Function&& function) = 0;
 
 protected:
     ITxSocket()  = default;
@@ -156,18 +154,16 @@ public:
 
     /// @brief Registers "ready to receive" callback function at a given executor.
     ///
-    /// The callback will be called by the executor when this socket will be ready to be read (MTU-worth data).
+    /// The callback will be called by an executor when this socket will be ready to be read (MTU-worth data).
     ///
     /// For example, POSIX socket implementation may pass its OS handle to the executor implementation,
     /// and executor will use `::poll` POSIX api & `POLLIN` event to schedule this callback for execution.
     ///
-    /// @param executor The executor to register the callback at.
     /// @param function The function to be called when TX socket became "ready to receive".
-    /// @return Type-erased instance of the registered callback. Instance must not outlive the executor,
-    ///         and must be used only with the same executor; otherwise undefined behavior.
+    /// @return Type-erased instance of the registered callback.
+    ///         Instance must not outlive the executor; otherwise undefined behavior.
     ///
-    CETL_NODISCARD virtual IExecutor::Callback::Any registerCallback(IExecutor&                      executor,
-                                                                     IExecutor::Callback::Function&& function) = 0;
+    CETL_NODISCARD virtual IExecutor::Callback::Any registerCallback(IExecutor::Callback::Function&& function) = 0;
 
 protected:
     IRxSocket()  = default;

--- a/test/unittest/platform/test_single_threaded_executor.cpp
+++ b/test/unittest/platform/test_single_threaded_executor.cpp
@@ -6,6 +6,7 @@
 #include "../gtest_helpers.hpp"  // NOLINT(misc-include-cleaner) `PrintTo`-s are implicitly in use by gtest.
 
 #include <cetl/pf17/cetlpf.hpp>
+#include <cetl/rtti.hpp>
 #include <cetl/unbounded_variant.hpp>
 #include <libcyphal/executor.hpp>
 #include <libcyphal/platform/single_threaded_executor.hpp>
@@ -15,6 +16,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <string>
 #include <thread>
@@ -37,7 +39,8 @@ using testing::Le;
 using testing::AllOf;
 using testing::IsNull;
 using testing::Return;
-using testing::IsEmpty;
+using testing::NotNull;
+using testing::InSequence;
 using testing::StrictMock;
 using testing::ElementsAre;
 
@@ -97,35 +100,54 @@ TEST_F(TestSingleThreadedExecutor, now)
     EXPECT_THAT(actual, AllOf(Ge(expected), Le(expected + epsilon)));
 }
 
+TEST_F(TestSingleThreadedExecutor, rtti)
+{
+    // mutable
+    {
+        SingleThreadedExecutor mut_executor;
+        EXPECT_THAT(cetl::rtti_cast<libcyphal::IExecutor*>(&mut_executor), NotNull());
+        EXPECT_THAT(cetl::rtti_cast<libcyphal::IExecutor::Callback::Interface*>(&mut_executor), IsNull());
+    }
+    // const
+    {
+        const SingleThreadedExecutor const_executor;
+        EXPECT_THAT(cetl::rtti_cast<libcyphal::IExecutor*>(&const_executor), NotNull());
+        EXPECT_THAT(cetl::rtti_cast<libcyphal::IExecutor::Callback::Interface*>(&const_executor), IsNull());
+    }
+}
+
 TEST_F(TestSingleThreadedExecutor, registerCallback)
 {
     MySingleThreadedExecutor executor;
 
-    auto nop = [](const TimePoint) {};
+    auto nop = [](const Callback::Arg&) {};
 
     Callback::Any cb1;
-    EXPECT_FALSE(cb1.has_value());
+    EXPECT_FALSE(cb1);
 
     cb1 = executor.registerCallback(nop);
-    EXPECT_TRUE(cb1.has_value());
+    EXPECT_TRUE(cb1);
 
     auto cb2a{executor.registerCallback(nop)};
-    EXPECT_TRUE(cb2a.has_value());
+    EXPECT_TRUE(cb2a);
 
-    // To cover RTTI non-const cast.
+    // To cover RTTI casts.
     EXPECT_THAT(cetl::get_if<libcyphal::transport::AnyFailure>(&cb2a), IsNull());
+    EXPECT_THAT(cetl::get_if<libcyphal::transport::AnyFailure>(static_cast<const Callback::Any*>(&cb2a)), IsNull());
+    EXPECT_THAT(cetl::get_if<libcyphal::IExecutor::Callback::Interface>(static_cast<const Callback::Any*>(&cb2a)),
+                NotNull());
 
     auto cb2b{std::move(cb2a)};
-    EXPECT_TRUE(cb2b.has_value());
+    EXPECT_TRUE(cb2b);
 
     cb2b = executor.registerCallback(nop);
-    EXPECT_TRUE(cb2b.has_value());
+    EXPECT_TRUE(cb2b);
 
     cb1 = {};
-    EXPECT_FALSE(cb1.has_value());
+    EXPECT_FALSE(cb1);
 
     cb2b = std::move(cb1);
-    EXPECT_FALSE(cb2b.has_value());
+    EXPECT_FALSE(cb2b);
 
     // To cover RTTI const cast.
     const auto cb3 = executor.registerCallback(nop);
@@ -139,22 +161,22 @@ TEST_F(TestSingleThreadedExecutor, scheduleAt_no_spin)
     auto virtual_now = TimePoint{};
 
     bool was_called = false;
-    auto callback   = executor.registerCallback([&](auto) { was_called = true; });
-    EXPECT_TRUE(callback.has_value());
+    auto callback   = executor.registerCallback([&](const auto&) { was_called = true; });
+    EXPECT_TRUE(callback);
     EXPECT_FALSE(was_called);
 
-    executor.scheduleCallback(callback, Schedule::Once{});
+    EXPECT_TRUE(callback.schedule(Schedule::Once{}));
     EXPECT_FALSE(was_called);
 
-    executor.scheduleCallback(callback, Schedule::Once{virtual_now + 1ms});
+    EXPECT_TRUE(callback.schedule(Schedule::Once{virtual_now + 1ms}));
     EXPECT_FALSE(was_called);
 
     callback.reset();
-    EXPECT_FALSE(callback.has_value());
+    EXPECT_FALSE(callback);
     EXPECT_FALSE(was_called);
 
     // callback is already reset
-    executor.scheduleCallback(callback, Schedule::Once{virtual_now});
+    EXPECT_FALSE(callback.schedule(Schedule::Once{virtual_now}));
 }
 
 TEST_F(TestSingleThreadedExecutor, spinOnce_no_callbacks)
@@ -174,7 +196,7 @@ TEST_F(TestSingleThreadedExecutor, spinOnce)
     MySingleThreadedExecutor executor;
 
     int  called   = 0;
-    auto callback = executor.registerCallback([&](auto) { ++called; });
+    auto callback = executor.registerCallback([&](const auto&) { ++called; });
 
     // Registered but not scheduled yet.
     //
@@ -186,8 +208,8 @@ TEST_F(TestSingleThreadedExecutor, spinOnce)
     EXPECT_THAT(spin_result.worst_lateness, Duration::zero());
     EXPECT_THAT(spin_result.approx_now, virtual_now);
 
-    executor.scheduleCallback(callback, Schedule::Once{virtual_now});
-    executor.scheduleCallback(callback, Schedule::Once{virtual_now + 4ms});
+    EXPECT_TRUE(callback.schedule(Schedule::Once{virtual_now}));
+    EXPECT_TRUE(callback.schedule(Schedule::Once{virtual_now + 4ms}));
 
     const auto deadline = virtual_now + 10ms;
 
@@ -204,44 +226,26 @@ TEST_F(TestSingleThreadedExecutor, spinOnce)
     EXPECT_THAT(called, 1);
 }
 
-TEST_F(TestSingleThreadedExecutor, schedule_none)
-{
-    MySingleThreadedExecutor executor;
-
-    std::vector<std::tuple<std::string, TimePoint>> calls;
-    auto cb1 = executor.registerCallback([&](auto now) { calls.emplace_back(std::make_tuple("1", now)); });
-
-    auto virtual_now = TimePoint{};
-    executor.scheduleCallback(cb1, Schedule::None{});
-
-    const auto deadline = virtual_now + 10ms;
-    EXPECT_CALL(executor.now_mock_, now()).WillRepeatedly(Return(virtual_now));
-
-    while (virtual_now < deadline)
-    {
-        const auto spin_result = executor.spinOnce();
-        EXPECT_THAT(spin_result.worst_lateness, Duration::zero());
-        EXPECT_THAT(spin_result.approx_now, virtual_now);
-
-        virtual_now += 1ms;
-        EXPECT_CALL(executor.now_mock_, now()).WillRepeatedly(Return(virtual_now));
-    }
-    EXPECT_THAT(calls, IsEmpty());
-}
-
 TEST_F(TestSingleThreadedExecutor, schedule_once_multiple)
 {
     MySingleThreadedExecutor executor;
 
-    std::vector<std::tuple<std::string, TimePoint>> calls;
-    auto cb1 = executor.registerCallback([&](auto now) { calls.emplace_back(std::make_tuple("1", now)); });
-    auto cb2 = executor.registerCallback([&](auto now) { calls.emplace_back(std::make_tuple("2", now)); });
-    auto cb3 = executor.registerCallback([&](auto now) { calls.emplace_back(std::make_tuple("3", now)); });
+    std::vector<std::tuple<std::string, TimePoint, TimePoint>> calls;
+
+    auto cb1 = executor.registerCallback([&](const auto& arg) {  //
+        calls.emplace_back(std::make_tuple("1", arg.exec_time, arg.approx_now));
+    });
+    auto cb2 = executor.registerCallback([&](const auto& arg) {  //
+        calls.emplace_back(std::make_tuple("2", arg.exec_time, arg.approx_now));
+    });
+    auto cb3 = executor.registerCallback([&](const auto& arg) {  //
+        calls.emplace_back(std::make_tuple("3", arg.exec_time, arg.approx_now));
+    });
 
     auto virtual_now = TimePoint{};
-    executor.scheduleCallback(cb1, Schedule::Once{virtual_now + 8ms});
-    executor.scheduleCallback(cb2, Schedule::Once{virtual_now + 3ms});
-    executor.scheduleCallback(cb3, Schedule::Once{virtual_now + 5ms});
+    EXPECT_TRUE(cb1.schedule(Schedule::Once{virtual_now + 8ms}));
+    EXPECT_TRUE(cb2.schedule(Schedule::Once{virtual_now + 3ms}));
+    EXPECT_TRUE(cb3.schedule(Schedule::Once{virtual_now + 5ms}));
 
     const auto deadline = virtual_now + 10ms;
     EXPECT_CALL(executor.now_mock_, now()).WillRepeatedly(Return(virtual_now));
@@ -256,25 +260,32 @@ TEST_F(TestSingleThreadedExecutor, schedule_once_multiple)
         EXPECT_CALL(executor.now_mock_, now()).WillRepeatedly(Return(virtual_now));
     }
     EXPECT_THAT(calls,
-                ElementsAre(std::make_tuple("2", TimePoint{3ms}),
-                            std::make_tuple("3", TimePoint{5ms}),
-                            std::make_tuple("1", TimePoint{8ms})));
+                ElementsAre(std::make_tuple("2", TimePoint{3ms}, TimePoint{3ms}),
+                            std::make_tuple("3", TimePoint{5ms}, TimePoint{5ms}),
+                            std::make_tuple("1", TimePoint{8ms}, TimePoint{8ms})));
 }
 
 TEST_F(TestSingleThreadedExecutor, schedule_once_multiple_with_the_same_exec_time)
 {
     MySingleThreadedExecutor executor;
 
-    std::vector<std::tuple<std::string, TimePoint>> calls;
-    auto cb1 = executor.registerCallback([&](auto now) { calls.emplace_back(std::make_tuple("1", now)); });
-    auto cb2 = executor.registerCallback([&](auto now) { calls.emplace_back(std::make_tuple("2", now)); });
-    auto cb3 = executor.registerCallback([&](auto now) { calls.emplace_back(std::make_tuple("3", now)); });
+    std::vector<std::tuple<std::string, TimePoint, TimePoint>> calls;
+
+    auto cb1 = executor.registerCallback([&](const auto& arg) {  //
+        calls.emplace_back(std::make_tuple("1", arg.exec_time, arg.approx_now));
+    });
+    auto cb2 = executor.registerCallback([&](const auto& arg) {  //
+        calls.emplace_back(std::make_tuple("2", arg.exec_time, arg.approx_now));
+    });
+    auto cb3 = executor.registerCallback([&](const auto& arg) {  //
+        calls.emplace_back(std::make_tuple("3", arg.exec_time, arg.approx_now));
+    });
 
     auto       virtual_now = TimePoint{};
     const auto exec_time   = virtual_now + 5ms;
-    executor.scheduleCallback(cb2, Schedule::Once{exec_time});
-    executor.scheduleCallback(cb1, Schedule::Once{exec_time});
-    executor.scheduleCallback(cb3, Schedule::Once{exec_time});
+    EXPECT_TRUE(cb2.schedule(Schedule::Once{exec_time}));
+    EXPECT_TRUE(cb1.schedule(Schedule::Once{exec_time}));
+    EXPECT_TRUE(cb3.schedule(Schedule::Once{exec_time}));
 
     const auto deadline = virtual_now + 10ms;
     EXPECT_CALL(executor.now_mock_, now()).WillRepeatedly(Return(virtual_now));
@@ -289,29 +300,29 @@ TEST_F(TestSingleThreadedExecutor, schedule_once_multiple_with_the_same_exec_tim
         EXPECT_CALL(executor.now_mock_, now()).WillRepeatedly(Return(virtual_now));
     }
     EXPECT_THAT(calls,
-                ElementsAre(std::make_tuple("2", TimePoint{5ms}),
-                            std::make_tuple("1", TimePoint{5ms}),
-                            std::make_tuple("3", TimePoint{5ms})));
+                ElementsAre(std::make_tuple("2", TimePoint{5ms}, TimePoint{5ms}),
+                            std::make_tuple("1", TimePoint{5ms}, TimePoint{5ms}),
+                            std::make_tuple("3", TimePoint{5ms}, TimePoint{5ms})));
 }
 
 TEST_F(TestSingleThreadedExecutor, schedule_once_callback_recursively)
 {
     MySingleThreadedExecutor executor;
 
-    std::vector<std::tuple<int, TimePoint>> calls;
+    std::vector<std::tuple<int, TimePoint, TimePoint>> calls;
 
     int           counter = 0;
     Callback::Any cb;
-    cb = executor.registerCallback([&](auto now) {
+    cb = executor.registerCallback([&](const auto& arg) {
         //
         ++counter;
-        calls.emplace_back(std::make_tuple(counter, now));
+        calls.emplace_back(std::make_tuple(counter, arg.exec_time, arg.approx_now));
 
-        executor.scheduleCallback(cb, Schedule::Once{now + 2ms});
+        EXPECT_TRUE(cb.schedule(Schedule::Once{arg.approx_now + 2ms}));
     });
 
     auto virtual_now = TimePoint{};
-    executor.scheduleCallback(cb, Schedule::Once{virtual_now + 5ms});
+    EXPECT_TRUE(cb.schedule(Schedule::Once{virtual_now + 5ms}));
 
     const auto deadline = virtual_now + 10ms;
     EXPECT_CALL(executor.now_mock_, now()).WillRepeatedly(Return(virtual_now));
@@ -326,29 +337,29 @@ TEST_F(TestSingleThreadedExecutor, schedule_once_callback_recursively)
         EXPECT_CALL(executor.now_mock_, now()).WillRepeatedly(Return(virtual_now));
     }
     EXPECT_THAT(calls,
-                ElementsAre(std::make_tuple(1, TimePoint{5ms}),
-                            std::make_tuple(2, TimePoint{7ms}),
-                            std::make_tuple(3, TimePoint{9ms})));
+                ElementsAre(std::make_tuple(1, TimePoint{5ms}, TimePoint{5ms}),
+                            std::make_tuple(2, TimePoint{7ms}, TimePoint{7ms}),
+                            std::make_tuple(3, TimePoint{9ms}, TimePoint{9ms})));
 }
 
 TEST_F(TestSingleThreadedExecutor, reset_once_scheduling_from_callback)
 {
     MySingleThreadedExecutor executor;
 
-    std::vector<std::tuple<int, TimePoint>> calls;
+    std::vector<std::tuple<int, TimePoint, TimePoint>> calls;
 
     int           counter = 0;
     Callback::Any cb;
-    cb = executor.registerCallback([&](auto now) {
+    cb = executor.registerCallback([&](const auto& arg) {
         //
         ++counter;
-        calls.emplace_back(std::make_tuple(counter, now));
+        calls.emplace_back(std::make_tuple(counter, arg.exec_time, arg.approx_now));
 
         cb.reset();
     });
 
     auto virtual_now = TimePoint{};
-    executor.scheduleCallback(cb, Schedule::Once{virtual_now + 5ms});
+    EXPECT_TRUE(cb.schedule(Schedule::Once{virtual_now + 5ms}));
 
     const auto deadline = virtual_now + 10ms;
     EXPECT_CALL(executor.now_mock_, now()).WillRepeatedly(Return(virtual_now));
@@ -363,20 +374,20 @@ TEST_F(TestSingleThreadedExecutor, reset_once_scheduling_from_callback)
         EXPECT_CALL(executor.now_mock_, now()).WillRepeatedly(Return(virtual_now));
     }
 
-    EXPECT_THAT(calls, ElementsAre(std::make_tuple(1, TimePoint{5ms})));
+    EXPECT_THAT(calls, ElementsAre(std::make_tuple(1, TimePoint{5ms}, TimePoint{5ms})));
 }
 
 TEST_F(TestSingleThreadedExecutor, reset_repeat_scheduling_from_callback)
 {
     MySingleThreadedExecutor executor;
 
-    std::vector<std::tuple<int, TimePoint>> calls;
+    std::vector<std::tuple<int, TimePoint, TimePoint>> calls;
 
     int           counter = 0;
-    Callback::Any cb      = executor.registerCallback([&](auto now) {
+    Callback::Any cb      = executor.registerCallback([&](const auto& arg) {
         //
         ++counter;
-        calls.emplace_back(std::make_tuple(counter, now));
+        calls.emplace_back(std::make_tuple(counter, arg.exec_time, arg.approx_now));
 
         if (counter == 3)
         {
@@ -385,7 +396,7 @@ TEST_F(TestSingleThreadedExecutor, reset_repeat_scheduling_from_callback)
     });
 
     auto virtual_now = TimePoint{};
-    executor.scheduleCallback(cb, Schedule::Repeat{virtual_now + 20ms, 5ms});
+    EXPECT_TRUE(cb.schedule(Schedule::Repeat{virtual_now + 20ms, 5ms}));
 
     const auto deadline = virtual_now + 100ms;
     EXPECT_CALL(executor.now_mock_, now()).WillRepeatedly(Return(virtual_now));
@@ -401,40 +412,44 @@ TEST_F(TestSingleThreadedExecutor, reset_repeat_scheduling_from_callback)
     }
 
     EXPECT_THAT(calls,
-                ElementsAre(std::make_tuple(1, TimePoint{20ms}),
-                            std::make_tuple(2, TimePoint{25ms}),
-                            std::make_tuple(3, TimePoint{30ms})));
+                ElementsAre(std::make_tuple(1, TimePoint{20ms}, TimePoint{20ms}),
+                            std::make_tuple(2, TimePoint{25ms}, TimePoint{25ms}),
+                            std::make_tuple(3, TimePoint{30ms}, TimePoint{30ms})));
 }
 
 TEST_F(TestSingleThreadedExecutor, spinOnce_worsth_lateness)
 {
     MySingleThreadedExecutor executor;
 
-    std::vector<std::tuple<int, TimePoint>> calls;
+    std::vector<std::tuple<int, TimePoint, TimePoint>> calls;
 
-    auto cb1 = executor.registerCallback([&](auto now) {
+    auto cb1 = executor.registerCallback([&](const auto& arg) {
         //
-        calls.emplace_back(std::make_tuple(1, now));
+        calls.emplace_back(std::make_tuple(1, arg.exec_time, arg.approx_now));
     });
-    auto cb2 = executor.registerCallback([&](auto now) {
+    auto cb2 = executor.registerCallback([&](const auto& arg) {
         //
-        calls.emplace_back(std::make_tuple(2, now));
+        calls.emplace_back(std::make_tuple(2, arg.exec_time, arg.approx_now));
     });
 
-    auto virtual_now = TimePoint{};
-    executor.scheduleCallback(cb1, Schedule::Once{virtual_now + 7ms});
-    executor.scheduleCallback(cb2, Schedule::Once{virtual_now + 4ms});
+    const TimePoint start_time = TimePoint{100ms};
+    EXPECT_TRUE(cb1.schedule(Schedule::Once{start_time + 7ms}));
+    EXPECT_TRUE(cb2.schedule(Schedule::Once{start_time + 4ms}));
 
     // Emulate lateness by spinning at +10ms
-    virtual_now += 10ms;
-    EXPECT_CALL(executor.now_mock_, now()).WillRepeatedly(Return(virtual_now));
+    const InSequence seq;
+    EXPECT_CALL(executor.now_mock_, now()).WillOnce(Return(start_time + 6ms));
+    EXPECT_CALL(executor.now_mock_, now()).WillOnce(Return(start_time + 15ms));
+    EXPECT_CALL(executor.now_mock_, now()).WillOnce(Return(start_time + 17ms));
 
     const auto spin_result = executor.spinOnce();
     EXPECT_THAT(spin_result.next_exec_time, Eq(cetl::nullopt));
-    EXPECT_THAT(spin_result.worst_lateness, 6ms);
-    EXPECT_THAT(spin_result.approx_now, virtual_now);
+    EXPECT_THAT(spin_result.worst_lateness, std::max(6ms - 4ms, 15ms - 7ms));
+    EXPECT_THAT(spin_result.approx_now, start_time + 17ms);
 
-    EXPECT_THAT(calls, ElementsAre(std::make_tuple(2, TimePoint{10ms}), std::make_tuple(1, TimePoint{10ms})));
+    EXPECT_THAT(calls,
+                ElementsAre(std::make_tuple(2, start_time + 4ms, start_time + 6ms),
+                            std::make_tuple(1, start_time + 7ms, start_time + 15ms)));
 }
 
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)

--- a/test/unittest/transport/can/media_mock.hpp
+++ b/test/unittest/transport/can/media_mock.hpp
@@ -49,12 +49,12 @@ public:
 
     MOCK_METHOD(IExecutor::Callback::Any,
                 registerPushCallback,
-                (IExecutor & executor, IExecutor::Callback::Function&& function),
+                (IExecutor::Callback::Function && function),
                 (override));
 
-    MOCK_METHOD(IExecutor::Callback::Any,
+    MOCK_METHOD(IExecutor::Callback::Any,  //
                 registerPopCallback,
-                (IExecutor & executor, IExecutor::Callback::Function&& function),
+                (IExecutor::Callback::Function && function),
                 (override));
 
 };  // MediaMock

--- a/test/unittest/transport/can/test_can_msg_rx_session.cpp
+++ b/test/unittest/transport/can/test_can_msg_rx_session.cpp
@@ -43,7 +43,6 @@ using libcyphal::verification_utilities::b;
 
 using testing::_;
 using testing::Eq;
-using testing::Ref;
 using testing::Invoke;
 using testing::Return;
 using testing::SizeIs;
@@ -106,8 +105,8 @@ TEST_F(TestCanMsgRxSession, make_setTransferIdTimeout)
 {
     auto transport = makeTransport(mr_);
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -158,8 +157,8 @@ TEST_F(TestCanMsgRxSession, receive)
     auto transport = makeTransport(mr_);
     transport->setTransientErrorHandler(std::ref(handler_mock));
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -182,7 +181,7 @@ TEST_F(TestCanMsgRxSession, receive)
 
     TimePoint rx_timestamp;
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         SCOPED_TRACE("1-st iteration: one frame available @ 1s");
 
@@ -198,7 +197,7 @@ TEST_F(TestCanMsgRxSession, receive)
             });
         scheduler_.scheduleNamedCallback("rx", rx_timestamp);
 
-        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             ASSERT_THAT(maybe_rx_transfer, Optional(_));
@@ -216,7 +215,7 @@ TEST_F(TestCanMsgRxSession, receive)
             EXPECT_THAT(buffer, ElementsAre('0', '1'));
         });
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         SCOPED_TRACE("2-nd iteration: no frames available @ 2s");
 
@@ -229,7 +228,7 @@ TEST_F(TestCanMsgRxSession, receive)
             });
         scheduler_.scheduleNamedCallback("rx", rx_timestamp);
 
-        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             EXPECT_THAT(maybe_rx_transfer, Eq(cetl::nullopt));
@@ -242,8 +241,8 @@ TEST_F(TestCanMsgRxSession, receive_one_anonymous_frame)
 {
     auto transport = makeTransport(mr_);
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -259,7 +258,7 @@ TEST_F(TestCanMsgRxSession, receive_one_anonymous_frame)
 
     TimePoint rx_timestamp;
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         rx_timestamp = now() + 10ms;
         EXPECT_CALL(media_mock_, pop(_))  //
@@ -273,7 +272,7 @@ TEST_F(TestCanMsgRxSession, receive_one_anonymous_frame)
             });
         scheduler_.scheduleNamedCallback("rx", rx_timestamp);
 
-        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             ASSERT_THAT(maybe_rx_transfer, Optional(_));
@@ -298,8 +297,8 @@ TEST_F(TestCanMsgRxSession, unsubscribe)
 {
     auto transport = makeTransport(mr_);
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -313,7 +312,7 @@ TEST_F(TestCanMsgRxSession, unsubscribe)
             return cetl::nullopt;
         });
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
             .WillOnce([&](Filters) {                     //

--- a/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
@@ -44,7 +44,6 @@ using libcyphal::verification_utilities::b;
 
 using testing::_;
 using testing::Eq;
-using testing::Ref;
 using testing::Invoke;
 using testing::Return;
 using testing::SizeIs;
@@ -111,8 +110,8 @@ TEST_F(TestCanSvcRxSessions, make_request_setTransferIdTimeout)
 {
     auto transport = makeTransport(mr_, 0x31);
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -160,8 +159,8 @@ TEST_F(TestCanSvcRxSessions, receive_request)
 {
     auto transport = makeTransport(mr_, 0x31);
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -186,7 +185,7 @@ TEST_F(TestCanSvcRxSessions, receive_request)
 
     TimePoint rx_timestamp;
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         SCOPED_TRACE("1-st iteration: one frame available @ 1s");
 
@@ -202,7 +201,7 @@ TEST_F(TestCanSvcRxSessions, receive_request)
             });
         scheduler_.scheduleNamedCallback("rx", rx_timestamp);
 
-        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             ASSERT_THAT(maybe_rx_transfer, Optional(_));
@@ -220,7 +219,7 @@ TEST_F(TestCanSvcRxSessions, receive_request)
             EXPECT_THAT(buffer, ElementsAre(42, 147));
         });
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         SCOPED_TRACE("2-nd iteration: no frames available @ 2s");
 
@@ -233,7 +232,7 @@ TEST_F(TestCanSvcRxSessions, receive_request)
             });
         scheduler_.scheduleNamedCallback("rx", rx_timestamp);
 
-        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             EXPECT_THAT(maybe_rx_transfer, Eq(cetl::nullopt));
@@ -247,8 +246,8 @@ TEST_F(TestCanSvcRxSessions, receive_response)
 {
     auto transport = makeTransport(mr_, 0x13);
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -274,7 +273,7 @@ TEST_F(TestCanSvcRxSessions, receive_response)
 
     TimePoint rx_timestamp;
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         SCOPED_TRACE("1-st iteration: one frame available @ 1s");
 
@@ -290,7 +289,7 @@ TEST_F(TestCanSvcRxSessions, receive_response)
             });
         scheduler_.scheduleNamedCallback("rx", rx_timestamp);
 
-        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             ASSERT_THAT(maybe_rx_transfer, Optional(_));
@@ -308,7 +307,7 @@ TEST_F(TestCanSvcRxSessions, receive_response)
             EXPECT_THAT(buffer, ElementsAre(42, 147));
         });
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         SCOPED_TRACE("2-nd iteration: no frames available @ 2s");
 
@@ -321,7 +320,7 @@ TEST_F(TestCanSvcRxSessions, receive_response)
             });
         scheduler_.scheduleNamedCallback("rx", rx_timestamp);
 
-        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             EXPECT_THAT(maybe_rx_transfer, Eq(cetl::nullopt));
@@ -335,8 +334,8 @@ TEST_F(TestCanSvcRxSessions, receive_two_frames)
 {
     auto transport = makeTransport(mr_, 0x31);
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -354,7 +353,7 @@ TEST_F(TestCanSvcRxSessions, receive_two_frames)
 
     auto first_rx_timestamp = TimePoint{1s + 10ms};
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, pop(_))  //
             .WillOnce([&](auto p) {
@@ -372,13 +371,13 @@ TEST_F(TestCanSvcRxSessions, receive_two_frames)
             });
         scheduler_.scheduleNamedCallback("rx", first_rx_timestamp);
 
-        scheduler_.scheduleAt(first_rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(first_rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             EXPECT_THAT(maybe_rx_transfer, Eq(cetl::nullopt));
         });
     });
-    scheduler_.scheduleAt(first_rx_timestamp + 3ms, [&](const TimePoint) {
+    scheduler_.scheduleAt(first_rx_timestamp + 3ms, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, pop(_))  //
             .WillOnce([&](auto p) {
@@ -394,7 +393,7 @@ TEST_F(TestCanSvcRxSessions, receive_two_frames)
             });
         scheduler_.scheduleNamedCallback("rx", now());
 
-        scheduler_.scheduleAt(now() + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(now() + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             ASSERT_THAT(maybe_rx_transfer, Optional(_));
@@ -419,8 +418,8 @@ TEST_F(TestCanSvcRxSessions, unsubscribe)
 {
     auto transport = makeTransport(mr_, 0x31);
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -435,7 +434,7 @@ TEST_F(TestCanSvcRxSessions, unsubscribe)
             return cetl::nullopt;
         });
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
             .WillOnce([&](Filters) {                     //

--- a/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
@@ -107,7 +107,7 @@ TEST_F(TestCanSvcTxSessions, make_request_session)
 {
     auto transport = makeTransport(mr_, 0);
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         auto maybe_session = transport->makeRequestTxSession({123, CANARD_NODE_ID_MAX});
         ASSERT_THAT(maybe_session, VariantWith<UniquePtr<IRequestTxSession>>(NotNull()));
@@ -124,13 +124,13 @@ TEST_F(TestCanSvcTxSessions, make_request_fails_due_to_argument_error)
     auto transport = makeTransport(mr_, 0);
 
     // Try invalid service id
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         auto maybe_session = transport->makeRequestTxSession({CANARD_SERVICE_ID_MAX + 1, 0});
         EXPECT_THAT(maybe_session, VariantWith<AnyFailure>(VariantWith<ArgumentError>(_)));
     });
     // Try invalid server node id
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         auto maybe_session = transport->makeRequestTxSession({0, CANARD_NODE_ID_MAX + 1});
         EXPECT_THAT(maybe_session, VariantWith<AnyFailure>(VariantWith<ArgumentError>(_)));
@@ -145,7 +145,7 @@ TEST_F(TestCanSvcTxSessions, make_request_fails_due_to_no_memory)
 
     auto transport = makeTransport(mr_mock, CANARD_NODE_ID_MAX);
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         // Emulate that there is no memory available for the message session.
         EXPECT_CALL(mr_mock, do_allocate(sizeof(can::detail::SvcRequestTxSession), _))  //
@@ -171,7 +171,7 @@ TEST_F(TestCanSvcTxSessions, send_request)
     const PayloadFragments empty_payload{};
     TransferMetadata       metadata{0x66, {}, Priority::Slow};
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
             .WillOnce([&](auto deadline, auto can_id, auto payload) {
@@ -185,8 +185,8 @@ TEST_F(TestCanSvcTxSessions, send_request)
                 EXPECT_THAT(payload, ElementsAre(tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
-        EXPECT_CALL(media_mock_, registerPushCallback(_, _))  //
-            .WillOnce(Invoke([](auto&, auto) { return libcyphal::IExecutor::Callback::Any{}; }));
+        EXPECT_CALL(media_mock_, registerPushCallback(_))  //
+            .WillOnce(Invoke([](auto) { return libcyphal::IExecutor::Callback::Any{}; }));
 
         metadata.timestamp = now();
         auto failure       = session->send(metadata, empty_payload);
@@ -214,14 +214,14 @@ TEST_F(TestCanSvcTxSessions, send_request_with_argument_error)
     TransferMetadata       metadata{0x66, {}, Priority::Immediate};
 
     // Should fail due to anonymous node.
-    scheduler_.scheduleAt(100ms, [&](const TimePoint) {
+    scheduler_.scheduleAt(100ms, [&](const auto&) {
         //
         metadata.timestamp = now();
         const auto failure = session->send(metadata, empty_payload);
         EXPECT_THAT(failure, Optional(VariantWith<ArgumentError>(_)));
     });
     // Fix anonymous node
-    scheduler_.scheduleAt(200ms, [&](const TimePoint) {
+    scheduler_.scheduleAt(200ms, [&](const auto&) {
         //
         EXPECT_THAT(transport->setLocalNodeId(13), Eq(cetl::nullopt));
 
@@ -237,8 +237,8 @@ TEST_F(TestCanSvcTxSessions, send_request_with_argument_error)
                 EXPECT_THAT(payload, ElementsAre(tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
-        EXPECT_CALL(media_mock_, registerPushCallback(_, _))  //
-            .WillOnce(Invoke([](auto&, auto) { return libcyphal::IExecutor::Callback::Any{}; }));
+        EXPECT_CALL(media_mock_, registerPushCallback(_))  //
+            .WillOnce(Invoke([](auto) { return libcyphal::IExecutor::Callback::Any{}; }));
 
         metadata.timestamp = now();
         const auto failure = session->send(metadata, empty_payload);
@@ -251,7 +251,7 @@ TEST_F(TestCanSvcTxSessions, make_response_session)
 {
     auto transport = makeTransport(mr_, CANARD_NODE_ID_MAX);
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         auto maybe_session = transport->makeResponseTxSession({123});
         ASSERT_THAT(maybe_session, VariantWith<UniquePtr<IResponseTxSession>>(NotNull()));
@@ -267,7 +267,7 @@ TEST_F(TestCanSvcTxSessions, make_response_fails_due_to_argument_error)
     auto transport = makeTransport(mr_, 0);
 
     // Try invalid service id
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         auto maybe_session = transport->makeResponseTxSession({CANARD_SERVICE_ID_MAX + 1});
         EXPECT_THAT(maybe_session, VariantWith<AnyFailure>(VariantWith<ArgumentError>(_)));
@@ -282,7 +282,7 @@ TEST_F(TestCanSvcTxSessions, make_response_fails_due_to_no_memory)
 
     auto transport = makeTransport(mr_mock, CANARD_NODE_ID_MAX);
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         // Emulate that there is no memory available for the message session.
         EXPECT_CALL(mr_mock, do_allocate(sizeof(can::detail::SvcRequestTxSession), _))  //
@@ -308,7 +308,7 @@ TEST_F(TestCanSvcTxSessions, send_response)
     const PayloadFragments  empty_payload{};
     ServiceTransferMetadata metadata{{0x66, {}, Priority::Fast}, 13};
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
             .WillOnce([&](auto deadline, auto can_id, auto payload) {
@@ -322,8 +322,8 @@ TEST_F(TestCanSvcTxSessions, send_response)
                 EXPECT_THAT(payload, ElementsAre(tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
-        EXPECT_CALL(media_mock_, registerPushCallback(_, _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {      //
+        EXPECT_CALL(media_mock_, registerPushCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("", now() + 10ms, std::move(function));
             }));
 
@@ -351,14 +351,14 @@ TEST_F(TestCanSvcTxSessions, send_response_with_argument_error)
     ServiceTransferMetadata metadata{{0x66, now(), Priority::Immediate}, 13};
 
     // Should fail due to anonymous node.
-    scheduler_.scheduleAt(100ms, [&](const TimePoint) {
+    scheduler_.scheduleAt(100ms, [&](const auto&) {
         //
         metadata.base.timestamp = now();
         const auto failure      = session->send(metadata, empty_payload);
         EXPECT_THAT(failure, Optional(VariantWith<ArgumentError>(_)));
     });
     // Fix anonymous node, but break remote node id.
-    scheduler_.scheduleAt(200ms, [&](const TimePoint) {
+    scheduler_.scheduleAt(200ms, [&](const auto&) {
         //
         EXPECT_THAT(transport->setLocalNodeId(31), Eq(cetl::nullopt));
 

--- a/test/unittest/transport/can/test_can_transport.cpp
+++ b/test/unittest/transport/can/test_can_transport.cpp
@@ -4,7 +4,7 @@
 /// SPDX-License-Identifier: MIT
 
 #include "../../cetl_gtest_helpers.hpp"  // NOLINT(misc-include-cleaner)
-#include "../../gtest_helpers.hpp"  // NOLINT(misc-include-cleaner)
+#include "../../gtest_helpers.hpp"       // NOLINT(misc-include-cleaner)
 #include "../../memory_resource_mock.hpp"
 #include "../../tracking_memory_resource.hpp"
 #include "../../verification_utilities.hpp"
@@ -15,7 +15,6 @@
 
 #include <canard.h>
 #include <cetl/pf17/cetlpf.hpp>
-#include <cetl/rtti.hpp>
 #include <libcyphal/transport/can/can_transport.hpp>
 #include <libcyphal/transport/can/can_transport_impl.hpp>
 #include <libcyphal/transport/can/media.hpp>
@@ -232,22 +231,22 @@ TEST_F(TestCanTransport, setLocalNodeId)
     EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
         .WillOnce([&](Filters) { return cetl::nullopt; });
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_THAT(transport->setLocalNodeId(CANARD_NODE_ID_MAX + 1), Optional(testing::A<ArgumentError>()));
         EXPECT_THAT(transport->getLocalNodeId(), Eq(cetl::nullopt));
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         EXPECT_THAT(transport->setLocalNodeId(CANARD_NODE_ID_MAX), Eq(cetl::nullopt));
         EXPECT_THAT(transport->getLocalNodeId(), Optional(CANARD_NODE_ID_MAX));
     });
-    scheduler_.scheduleAt(3s, [&](const TimePoint) {
+    scheduler_.scheduleAt(3s, [&](const auto&) {
         //
         EXPECT_THAT(transport->setLocalNodeId(CANARD_NODE_ID_MAX), Eq(cetl::nullopt));
         EXPECT_THAT(transport->getLocalNodeId(), Optional(CANARD_NODE_ID_MAX));
     });
-    scheduler_.scheduleAt(4s, [&](const TimePoint) {
+    scheduler_.scheduleAt(4s, [&](const auto&) {
         //
         EXPECT_THAT(transport->setLocalNodeId(0), Optional(testing::A<ArgumentError>()));
         EXPECT_THAT(transport->getLocalNodeId(), Optional(CANARD_NODE_ID_MAX));
@@ -298,10 +297,10 @@ TEST_F(TestCanTransport, makeMessageRxSession)
     EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
         .WillOnce([&](Filters) { return cetl::nullopt; });
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
-        EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                   //
+        EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {         //
                 return scheduler_.registerNamedCallback("rx", std::move(function));
             }));
 
@@ -327,7 +326,7 @@ TEST_F(TestCanTransport, makeMessageRxSession_invalid_subject_id)
     EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
         .WillOnce([&](Filters) { return cetl::nullopt; });
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         auto maybe_rx_session = transport->makeMessageRxSession({0, CANARD_SUBJECT_ID_MAX + 1});
         EXPECT_THAT(maybe_rx_session, VariantWith<AnyFailure>(VariantWith<ArgumentError>(_)));
@@ -344,10 +343,10 @@ TEST_F(TestCanTransport, makeMessageRxSession_invalid_resubscription)
 
     const PortId test_subject_id = 111;
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
-        EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                   //
+        EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {         //
                 return scheduler_.registerNamedCallback("rx", std::move(function));
             }));
 
@@ -360,10 +359,10 @@ TEST_F(TestCanTransport, makeMessageRxSession_invalid_resubscription)
         EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
             .WillOnce([&](Filters) { return cetl::nullopt; });
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
-        EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                   //
+        EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {         //
                 return scheduler_.registerNamedCallback("rx", std::move(function));
             }));
 
@@ -385,10 +384,10 @@ TEST_F(TestCanTransport, makeRequestRxSession_invalid_resubscription)
 
     const PortId test_subject_id = 111;
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
-        EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                   //
+        EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {         //
                 return scheduler_.registerNamedCallback("rx", std::move(function));
             }));
 
@@ -401,10 +400,10 @@ TEST_F(TestCanTransport, makeRequestRxSession_invalid_resubscription)
         EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
             .WillOnce([&](Filters) { return cetl::nullopt; });
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
-        EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                   //
+        EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {         //
                 return scheduler_.registerNamedCallback("rx", std::move(function));
             }));
 
@@ -426,10 +425,10 @@ TEST_F(TestCanTransport, makeResponseRxSession_invalid_resubscription)
 
     const PortId test_subject_id = 111;
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
-        EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                   //
+        EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {         //
                 return scheduler_.registerNamedCallback("rx", std::move(function));
             }));
 
@@ -442,10 +441,10 @@ TEST_F(TestCanTransport, makeResponseRxSession_invalid_resubscription)
         EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
             .WillOnce([&](Filters) { return cetl::nullopt; });
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
-        EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                   //
+        EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {         //
                 return scheduler_.registerNamedCallback("rx", std::move(function));
             }));
 
@@ -465,7 +464,7 @@ TEST_F(TestCanTransport, makeMessageTxSession)
     EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
         .WillOnce([&](Filters) { return cetl::nullopt; });
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         auto maybe_tx_session = transport->makeMessageTxSession({123});
         ASSERT_THAT(maybe_tx_session, VariantWith<UniquePtr<IMessageTxSession>>(NotNull()));
@@ -490,7 +489,7 @@ TEST_F(TestCanTransport, sending_multiframe_payload_should_fail_for_anonymous)
     EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
         .WillOnce([&](Filters) { return cetl::nullopt; });
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         metadata.timestamp = now();
         auto failure       = session->send(metadata, makeSpansFrom(payload));
@@ -517,7 +516,7 @@ TEST_F(TestCanTransport, sending_multiframe_payload_for_non_anonymous)
     EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
         .WillOnce([&](Filters) { return cetl::nullopt; });
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _)).WillOnce([&](auto deadline, auto can_id, auto payload) {
             EXPECT_THAT(now(), metadata.timestamp);
@@ -529,8 +528,8 @@ TEST_F(TestCanTransport, sending_multiframe_payload_for_non_anonymous)
             EXPECT_THAT(payload, ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
             return IMedia::PushResult::Success{true /* is_accepted */};
         });
-        EXPECT_CALL(media_mock_, registerPushCallback(_, _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {      //
+        EXPECT_CALL(media_mock_, registerPushCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("", now() + 10us, std::move(function));
             }));
 
@@ -538,7 +537,7 @@ TEST_F(TestCanTransport, sending_multiframe_payload_for_non_anonymous)
         auto failure       = session->send(metadata, makeSpansFrom(payload));
         EXPECT_THAT(failure, Eq(cetl::nullopt));
     });
-    scheduler_.scheduleAt(1s + 10us, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s + 10us, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _)).WillOnce([&](auto deadline, auto can_id, auto payload) {
             EXPECT_THAT(now(), metadata.timestamp + 10us);
@@ -577,7 +576,7 @@ TEST_F(TestCanTransport, send_multiframe_payload_to_redundant_not_ready_media)
     EXPECT_CALL(media_mock2, setFilters(IsEmpty()))  //
         .WillOnce([&](Filters) { return cetl::nullopt; });
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         // Emulate once that the first media is not ready to push fragment (@10us). So transport will switch to
         // the second media, and will retry with the 1st only when its socket is ready @ +20us.
@@ -587,8 +586,8 @@ TEST_F(TestCanTransport, send_multiframe_payload_to_redundant_not_ready_media)
                 EXPECT_THAT(now(), metadata.timestamp);
                 return IMedia::PushResult::Success{false /* is_accepted */};
             });
-        EXPECT_CALL(media_mock_, registerPushCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                    //
+        EXPECT_CALL(media_mock_, registerPushCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("tx1", now() + 20us, std::move(function));
             }));
         EXPECT_CALL(media_mock2, push(_, _, _))  //
@@ -602,8 +601,8 @@ TEST_F(TestCanTransport, send_multiframe_payload_to_redundant_not_ready_media)
                 EXPECT_THAT(payload, ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
-        EXPECT_CALL(media_mock2, registerPushCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                    //
+        EXPECT_CALL(media_mock2, registerPushCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("tx2", now() + 10us, std::move(function));
             }));
 
@@ -611,7 +610,7 @@ TEST_F(TestCanTransport, send_multiframe_payload_to_redundant_not_ready_media)
         auto failure       = session->send(metadata, makeSpansFrom(payload));
         EXPECT_THAT(failure, Eq(cetl::nullopt));
     });
-    scheduler_.scheduleAt(1s + 10us, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s + 10us, [&](const auto&) {
         //
         EXPECT_CALL(media_mock2, push(_, _, _))  //
             .WillOnce([&](auto deadline, auto can_id, auto payload) {
@@ -625,7 +624,7 @@ TEST_F(TestCanTransport, send_multiframe_payload_to_redundant_not_ready_media)
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
     });
-    scheduler_.scheduleAt(1s + 20us, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s + 20us, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
             .WillOnce([&](auto deadline, auto can_id, auto payload) {
@@ -668,7 +667,7 @@ TEST_F(TestCanTransport, send_payload_to_redundant_fallible_media)
         .WillOnce([&](Filters) { return cetl::nullopt; });
 
     // 1. First attempt to push payload.
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         // Media #0 failed to push, but not media #2 - its frame should be dropped (but not for #2).
         //
@@ -684,8 +683,8 @@ TEST_F(TestCanTransport, send_payload_to_redundant_fallible_media)
         //
         EXPECT_CALL(media_mock2, push(_, _, _))  //
             .WillOnce(Return(IMedia::PushResult::Success{true /* is_accepted */}));
-        EXPECT_CALL(media_mock2, registerPushCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                    //
+        EXPECT_CALL(media_mock2, registerPushCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("", now() + 20us, std::move(function));
             }));
 
@@ -693,14 +692,14 @@ TEST_F(TestCanTransport, send_payload_to_redundant_fallible_media)
         EXPECT_THAT(session->send(metadata, makeSpansFrom(payload)), Eq(cetl::nullopt));
     });
     // 2. Second attempt to push payload (while 1st attempt still in progress for socket 2).
-    scheduler_.scheduleAt(1s + 10us, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s + 10us, [&](const auto&) {
         //
         // Socket #0 is fine but Socket #2 failed to send - its frame should be dropped (but not for #0).
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
             .WillOnce(Return(IMedia::PushResult::Success{true /* is_accepted */}));
-        EXPECT_CALL(media_mock_, registerPushCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                    //
+        EXPECT_CALL(media_mock_, registerPushCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("", now() + 5us, std::move(function));
             }));
         //
@@ -747,7 +746,7 @@ TEST_F(TestCanTransport, send_payload_to_out_of_capacity_canard_tx)
         .WillOnce([&](Filters) { return cetl::nullopt; });
 
     // 1st. Try to send a frame with "failing" handler - only the 0-th media index will be used.
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(handler_mock, invoke(VariantWith<CanardTxPushReport>(Truly([](auto& report) {
                         EXPECT_THAT(report.failure, VariantWith<MemoryError>(_));
@@ -765,7 +764,7 @@ TEST_F(TestCanTransport, send_payload_to_out_of_capacity_canard_tx)
         EXPECT_THAT(failure, Optional(VariantWith<StateError>(_)));
     });
     // 2nd. Try to send a frame with "succeeding" handler - both media indices will be used.
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(handler_mock, invoke(VariantWith<CanardTxPushReport>(Truly([](auto& report) {
                         EXPECT_THAT(report.failure, VariantWith<MemoryError>(_));
@@ -794,12 +793,12 @@ TEST_F(TestCanTransport, receive_svc_responses_from_redundant_media)
     auto transport = makeTransport(mr_, &media_mock2);
     EXPECT_THAT(transport->setLocalNodeId(0x13), Eq(cetl::nullopt));
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx1", std::move(function));
         }));
-    EXPECT_CALL(media_mock2, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock2, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx2", std::move(function));
         }));
 
@@ -827,7 +826,7 @@ TEST_F(TestCanTransport, receive_svc_responses_from_redundant_media)
     constexpr auto rx1_timestamp = TimePoint{10s};
     constexpr auto rx2_timestamp = rx1_timestamp + 2 * timeout;
 
-    scheduler_.scheduleAt(rx1_timestamp, [&](const TimePoint) {
+    scheduler_.scheduleAt(rx1_timestamp, [&](const auto&) {
         //
         // 1. Emulate that only one 1st frame came from the 1st media interface (@ rx1_timestamp)...
         //
@@ -846,7 +845,7 @@ TEST_F(TestCanTransport, receive_svc_responses_from_redundant_media)
             });
         scheduler_.scheduleNamedCallback("rx1", rx1_timestamp);
     });
-    scheduler_.scheduleAt(rx2_timestamp, [&](const TimePoint) {
+    scheduler_.scheduleAt(rx2_timestamp, [&](const auto&) {
         //
         // 2. And then 2nd media delivered all frames once again after timeout (@ rx2_timestamp).
         //
@@ -865,7 +864,7 @@ TEST_F(TestCanTransport, receive_svc_responses_from_redundant_media)
             });
         scheduler_.scheduleNamedCallback("rx2", rx1_timestamp);
     });
-    scheduler_.scheduleAt(rx2_timestamp + 1ms, [&](const TimePoint) {
+    scheduler_.scheduleAt(rx2_timestamp + 1ms, [&](const auto&) {
         //
         EXPECT_CALL(media_mock2, pop(_))  //
             .WillOnce([&](auto p) {
@@ -880,7 +879,7 @@ TEST_F(TestCanTransport, receive_svc_responses_from_redundant_media)
             });
         scheduler_.scheduleNamedCallback("rx2", rx1_timestamp);
     });
-    scheduler_.scheduleAt(rx2_timestamp + 2ms, [&](const TimePoint) {
+    scheduler_.scheduleAt(rx2_timestamp + 2ms, [&](const auto&) {
         //
         const auto maybe_rx_transfer = session->receive();
         ASSERT_THAT(maybe_rx_transfer, Optional(_));
@@ -897,7 +896,7 @@ TEST_F(TestCanTransport, receive_svc_responses_from_redundant_media)
         EXPECT_THAT(rx_transfer.payload.copy(0, buffer.data(), buffer.size()), buffer.size());
         EXPECT_THAT(buffer, ElementsAre('0', '1', '2', '3', '4', '5', '6', '7', '8', '9'));
     });
-    scheduler_.scheduleAt(99s, [&](const TimePoint) {
+    scheduler_.scheduleAt(99s, [&](const auto&) {
         //
         SCOPED_TRACE("unsubscribe @ 99s");
 
@@ -929,12 +928,12 @@ TEST_F(TestCanTransport, receive_svc_responses_from_redundant_fallible_media)
     auto transport = makeTransport(mr_, &media_mock2);
     EXPECT_THAT(transport->setLocalNodeId(0x13), Eq(cetl::nullopt));
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx1", std::move(function));
         }));
-    EXPECT_CALL(media_mock2, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock2, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx2", std::move(function));
         }));
 
@@ -947,13 +946,13 @@ TEST_F(TestCanTransport, receive_svc_responses_from_redundant_fallible_media)
     EXPECT_CALL(media_mock2, setFilters(_)).WillOnce(Return(cetl::nullopt));
 
     // 1st run: media #0 pop has failed and there is no transient error handler.
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, pop(_)).WillOnce(Return(ArgumentError{}));
         scheduler_.scheduleNamedCallback("rx1");
     });
     // 2nd run: media #0 pop and transient error handler have failed.
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         transport->setTransientErrorHandler(std::ref(handler_mock));
         EXPECT_CALL(handler_mock, invoke(VariantWith<MediaPopReport>(Truly([&](auto& report) {
@@ -968,7 +967,7 @@ TEST_F(TestCanTransport, receive_svc_responses_from_redundant_fallible_media)
         scheduler_.scheduleNamedCallback("rx1");
     });
     // 3rd run: media #0 pop failed but transient error handler succeeded.
-    scheduler_.scheduleAt(3s, [&](const TimePoint) {
+    scheduler_.scheduleAt(3s, [&](const auto&) {
         //
         EXPECT_CALL(handler_mock, invoke(VariantWith<MediaPopReport>(Truly([&](auto& report) {
                         EXPECT_THAT(report.failure, VariantWith<ArgumentError>(_));
@@ -996,8 +995,8 @@ TEST_F(TestCanTransport, receive_svc_responses_with_fallible_oom_canard)
     auto transport = makeTransport(mr_mock);
     EXPECT_THAT(transport->setLocalNodeId(0x13), Eq(cetl::nullopt));
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -1021,42 +1020,42 @@ TEST_F(TestCanTransport, receive_svc_responses_with_fallible_oom_canard)
 #endif
 
     // 1st run: canard RX has failed to accept frame and there is no transient error handler.
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         scheduler_.scheduleNamedCallback("rx");
-        scheduler_.scheduleAt(now() + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(now() + 1ms, [&](const auto&) {
             //
             EXPECT_THAT(session->receive(), Eq(cetl::nullopt));
         });
     });
     // 2nd run: canard RX has failed to accept frame and there is "failing" transient error handler.
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         transport->setTransientErrorHandler(std::ref(handler_mock));
         scheduler_.scheduleNamedCallback("rx");
         EXPECT_CALL(handler_mock, invoke(_)).WillOnce(Return(StateError{}));
-        scheduler_.scheduleAt(now() + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(now() + 1ms, [&](const auto&) {
             //
             EXPECT_THAT(session->receive(), Eq(cetl::nullopt));
         });
     });
     // 3rd run: canard RX has failed to accept frame and there is "success" transient error handler -
     // the received frame should be just dropped, but overall `run` result should be success (aka ignore OOM).
-    scheduler_.scheduleAt(3s, [&](const TimePoint) {
+    scheduler_.scheduleAt(3s, [&](const auto&) {
         //
         EXPECT_CALL(handler_mock, invoke(_)).WillOnce(Return(cetl::nullopt));
         scheduler_.scheduleNamedCallback("rx");
-        scheduler_.scheduleAt(now() + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(now() + 1ms, [&](const auto&) {
             //
             EXPECT_THAT(session->receive(), Eq(cetl::nullopt));
         });
     });
     // 4th run: fix memory problems - now we should receive the payload.
-    scheduler_.scheduleAt(4s, [&](const TimePoint) {
+    scheduler_.scheduleAt(4s, [&](const auto&) {
         //
         mr_mock.redirectExpectedCallsTo(mr_);
         scheduler_.scheduleNamedCallback("rx");
-        scheduler_.scheduleAt(now() + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(now() + 1ms, [&](const auto&) {
             //
             EXPECT_THAT(session->receive(), Optional(Truly([](const auto& rx_transfer) {
                             EXPECT_THAT(rx_transfer.metadata.base.transfer_id, 0x1D);
@@ -1079,8 +1078,8 @@ TEST_F(TestCanTransport, setLocalNodeId_when_msg_rx_subscription)
 {
     auto transport = makeTransport(mr_);
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -1089,7 +1088,7 @@ TEST_F(TestCanTransport, setLocalNodeId_when_msg_rx_subscription)
 
     EXPECT_CALL(media_mock_, setFilters(SizeIs(1))).WillOnce(Return(cetl::nullopt));
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         ASSERT_THAT(transport->setLocalNodeId(0x13), Eq(cetl::nullopt));
 
@@ -1102,8 +1101,8 @@ TEST_F(TestCanTransport, setLocalNodeId_when_svc_rx_subscription)
 {
     auto transport = makeTransport(mr_);
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -1118,7 +1117,7 @@ TEST_F(TestCanTransport, setLocalNodeId_when_svc_rx_subscription)
         return cetl::nullopt;
     });
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         ASSERT_THAT(transport->setLocalNodeId(0x13), Eq(cetl::nullopt));
 
@@ -1138,8 +1137,8 @@ TEST_F(TestCanTransport, setFilters_no_memory)
 
     auto transport = makeTransport(mr_mock);
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx", std::move(function));
         }));
 
@@ -1153,7 +1152,7 @@ TEST_F(TestCanTransport, setFilters_no_memory)
     EXPECT_CALL(mr_mock, do_reallocate(nullptr, 0, _, _)).WillOnce(Return(nullptr));
 #endif
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         // Restore normal memory operation, but make media fail to accept filters.
         //
@@ -1161,7 +1160,7 @@ TEST_F(TestCanTransport, setFilters_no_memory)
         EXPECT_CALL(media_mock_, setFilters(SizeIs(1))).WillOnce(Return(PlatformError{MyPlatformError{13}}));
         maybe_msg_session = transport->makeMessageRxSession({0, 0x43});
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, setFilters(SizeIs(1))).WillOnce(Return(cetl::nullopt));
         maybe_msg_session = transport->makeMessageRxSession({0, 0x42});
@@ -1178,12 +1177,12 @@ TEST_F(TestCanTransport, setFilters_with_transient_handler)
 
     auto transport = makeTransport(mr_, &media_mock2);
 
-    EXPECT_CALL(media_mock_, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock_, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx1", std::move(function));
         }));
-    EXPECT_CALL(media_mock2, registerPopCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                   //
+    EXPECT_CALL(media_mock2, registerPopCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {         //
             return scheduler_.registerNamedCallback("rx2", std::move(function));
         }));
 
@@ -1210,16 +1209,3 @@ TEST_F(TestCanTransport, setFilters_with_transient_handler)
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
 
 }  // namespace
-
-namespace cetl
-{
-
-// Just random id: AD188CA2-0582-47A0-BCCF-C20E5E146213
-template <>
-constexpr type_id type_id_getter<MyPlatformError>() noexcept
-{
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
-    return {0xAD, 0x18, 0x8C, 0xA2, 0x05, 0x82, 0x47, 0xA0, 0xBC, 0xCF, 0xC2, 0x0E, 0x5E, 0x14, 0x62, 0x13};
-}
-
-}  // namespace cetl

--- a/test/unittest/transport/udp/test_udp_msg_tx_session.cpp
+++ b/test/unittest/transport/udp/test_udp_msg_tx_session.cpp
@@ -115,7 +115,7 @@ TEST_F(TestUdpMsgTxSession, make)
 {
     auto transport = makeTransport({mr_});
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         auto maybe_session = transport->makeMessageTxSession({123});
         ASSERT_THAT(maybe_session, VariantWith<UniquePtr<IMessageTxSession>>(NotNull()));
@@ -133,7 +133,7 @@ TEST_F(TestUdpMsgTxSession, make_no_memory)
 
     auto transport = makeTransport({mr_mock});
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         // Emulate that there is no memory available for the message session.
         EXPECT_CALL(mr_mock, do_allocate(sizeof(udp::detail::MessageTxSession), _))  //
@@ -150,7 +150,7 @@ TEST_F(TestUdpMsgTxSession, make_fails_due_to_argument_error)
     auto transport = makeTransport({mr_});
 
     // Try invalid subject id
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         auto maybe_session = transport->makeMessageTxSession({UDPARD_SUBJECT_ID_MAX + 1});
         EXPECT_THAT(maybe_session, VariantWith<AnyFailure>(VariantWith<ArgumentError>(_)));
@@ -165,7 +165,7 @@ TEST_F(TestUdpMsgTxSession, make_fails_due_to_media_socket)
     auto transport = makeTransport({mr_});
 
     // 1. Transport will fail to make msg TX session b/c media fails to create a TX socket.
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, makeTxSocket())  //
             .WillOnce(Return(MemoryError{}));
@@ -181,7 +181,7 @@ TEST_F(TestUdpMsgTxSession, make_fails_due_to_media_socket)
     });
     // 2. Transport will succeed to make TX session despite the media fails to create a TX socket.
     //    This is b/c transient error handler will be set and will handle the error.
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, makeTxSocket())  //
             .WillOnce(Return(MemoryError{}));
@@ -220,7 +220,7 @@ TEST_F(TestUdpMsgTxSession, send_empty_payload)
     const PayloadFragments empty_payload{};
     TransferMetadata       metadata{0x1AF52, {}, Priority::Low};
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         // TX item for our payload to send is expected to be de/allocated on the *fragment* memory resource.
         //
@@ -237,8 +237,8 @@ TEST_F(TestUdpMsgTxSession, send_empty_payload)
         //
         EXPECT_CALL(tx_socket_mock_, send(_, _, _, _))
             .WillOnce(Return(ITxSocket::SendResult::Success{false /* is_accepted */}));
-        EXPECT_CALL(tx_socket_mock_, registerCallback(_, _))  //
-            .WillOnce(Invoke([](auto&, auto) { return libcyphal::IExecutor::Callback::Any{}; }));
+        EXPECT_CALL(tx_socket_mock_, registerCallback(_))  //
+            .WillOnce(Invoke([](auto) { return libcyphal::IExecutor::Callback::Any{}; }));
 
         metadata.timestamp = now();
         auto failure       = session->send(metadata, empty_payload);
@@ -264,13 +264,13 @@ TEST_F(TestUdpMsgTxSession, send_empty_expired_payload)
     const PayloadFragments empty_payload{};
     TransferMetadata       metadata{0x11, {}, Priority::Low};
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         // Emulate that socket became ready on the very edge of the default 1s timeout (exactly at the deadline).
         EXPECT_CALL(tx_socket_mock_, send(_, _, _, _))
             .WillOnce(Return(ITxSocket::SendResult::Success{false /* is_accepted */}));
-        EXPECT_CALL(tx_socket_mock_, registerCallback(_, _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {      //
+        EXPECT_CALL(tx_socket_mock_, registerCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("", now() + timeout, std::move(function));
             }));
 
@@ -295,13 +295,13 @@ TEST_F(TestUdpMsgTxSession, send_single_frame_payload_with_500ms_timeout)
     const auto       payload = makeIotaArray<UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME>(b('1'));
     TransferMetadata metadata{0x03, {}, Priority::High};
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         // Emulate that socket became ready on the very edge of the 500ms timeout (just 1us before the deadline).
         EXPECT_CALL(tx_socket_mock_, send(_, _, _, _))
             .WillOnce(Return(ITxSocket::SendResult::Success{false /* is_accepted */}));
-        EXPECT_CALL(tx_socket_mock_, registerCallback(_, _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {      //
+        EXPECT_CALL(tx_socket_mock_, registerCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("", now() + timeout - 1us, std::move(function));
             }));
 
@@ -309,7 +309,7 @@ TEST_F(TestUdpMsgTxSession, send_single_frame_payload_with_500ms_timeout)
         auto failure       = session->send(metadata, makeSpansFrom(payload));
         EXPECT_THAT(failure, Eq(cetl::nullopt));
     });
-    scheduler_.scheduleAt(1s + timeout - 1us, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s + timeout - 1us, [&](const auto&) {
         //
         EXPECT_CALL(tx_socket_mock_, send(_, _, _, _))  //
             .WillOnce([&](auto, auto endpoint, auto dscp, auto fragments) {
@@ -348,7 +348,7 @@ TEST_F(TestUdpMsgTxSession, send_when_no_memory_for_contiguous_payload)
 
     TransferMetadata metadata{0x03, {}, Priority::Optional};
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         metadata.timestamp = now();
         auto failure       = session->send(metadata, makeSpansFrom(payload1, payload2));

--- a/test/unittest/transport/udp/test_udp_svc_rx_sessions.cpp
+++ b/test/unittest/transport/udp/test_udp_svc_rx_sessions.cpp
@@ -249,8 +249,8 @@ TEST_F(TestUdpSvcRxSessions, receive_request)
     EXPECT_THAT(rx_socket_mock_.getEndpoint().ip_address, 0);
     EXPECT_THAT(rx_socket_mock_.getEndpoint().udp_port, 0);
 
-    EXPECT_CALL(rx_socket_mock_, registerCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                    //
+    EXPECT_CALL(rx_socket_mock_, registerCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {          //
             return scheduler_.registerNamedCallback("rx_socket", std::move(function));
         }));
 
@@ -271,7 +271,7 @@ TEST_F(TestUdpSvcRxSessions, receive_request)
 
     TimePoint rx_timestamp;
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         SCOPED_TRACE("1-st iteration: one frame available @ 1s");
 
@@ -295,7 +295,7 @@ TEST_F(TestUdpSvcRxSessions, receive_request)
             });
         scheduler_.scheduleNamedCallback("rx_socket", rx_timestamp);
 
-        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             ASSERT_THAT(maybe_rx_transfer, Optional(_));
@@ -318,7 +318,7 @@ TEST_F(TestUdpSvcRxSessions, receive_request)
                 });
         });
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         SCOPED_TRACE("2-nd iteration: invalid null frame available @ 2s");
 
@@ -329,13 +329,13 @@ TEST_F(TestUdpSvcRxSessions, receive_request)
             });
         scheduler_.scheduleNamedCallback("rx_socket", rx_timestamp);
 
-        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             EXPECT_THAT(maybe_rx_transfer, Eq(cetl::nullopt));
         });
     });
-    scheduler_.scheduleAt(3s, [&](const TimePoint) {
+    scheduler_.scheduleAt(3s, [&](const auto&) {
         //
         SCOPED_TRACE("3-rd iteration: malformed frame available @ 3s - no error, just drop");
 
@@ -361,7 +361,7 @@ TEST_F(TestUdpSvcRxSessions, receive_request)
             });
         scheduler_.scheduleNamedCallback("rx_socket", rx_timestamp);
 
-        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             EXPECT_THAT(maybe_rx_transfer, Eq(cetl::nullopt));
@@ -380,8 +380,8 @@ TEST_F(TestUdpSvcRxSessions, receive_response)
     EXPECT_THAT(rx_socket_mock_.getEndpoint().ip_address, 0);
     EXPECT_THAT(rx_socket_mock_.getEndpoint().udp_port, 0);
 
-    EXPECT_CALL(rx_socket_mock_, registerCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                    //
+    EXPECT_CALL(rx_socket_mock_, registerCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {          //
             return scheduler_.registerNamedCallback("rx_socket", std::move(function));
         }));
 
@@ -403,7 +403,7 @@ TEST_F(TestUdpSvcRxSessions, receive_response)
 
     TimePoint rx_timestamp;
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         SCOPED_TRACE("1-st iteration: one frame available @ 1s");
 
@@ -427,7 +427,7 @@ TEST_F(TestUdpSvcRxSessions, receive_response)
             });
         scheduler_.scheduleNamedCallback("rx_socket", rx_timestamp);
 
-        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             ASSERT_THAT(maybe_rx_transfer, Optional(_));
@@ -450,7 +450,7 @@ TEST_F(TestUdpSvcRxSessions, receive_response)
                 });
         });
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         SCOPED_TRACE("2-nd iteration: media RX socket error @ 2s");
 
@@ -462,7 +462,7 @@ TEST_F(TestUdpSvcRxSessions, receive_response)
             });
         scheduler_.scheduleNamedCallback("rx_socket", rx_timestamp);
 
-        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const TimePoint) {
+        scheduler_.scheduleAt(rx_timestamp + 1ms, [&](const auto&) {
             //
             const auto maybe_rx_transfer = session->receive();
             EXPECT_THAT(maybe_rx_transfer, Eq(cetl::nullopt));
@@ -475,8 +475,8 @@ TEST_F(TestUdpSvcRxSessions, unsubscribe)
 {
     auto transport = makeTransport({mr_}, NodeId{0x31});
 
-    EXPECT_CALL(rx_socket_mock_, registerCallback(Ref(scheduler_), _))  //
-        .WillOnce(Invoke([&](auto&, auto function) {                    //
+    EXPECT_CALL(rx_socket_mock_, registerCallback(_))  //
+        .WillOnce(Invoke([&](auto function) {          //
             return scheduler_.registerCallback(std::move(function));
         }));
 
@@ -485,7 +485,7 @@ TEST_F(TestUdpSvcRxSessions, unsubscribe)
     ASSERT_THAT(maybe_session, VariantWith<UniquePtr<IRequestRxSession>>(NotNull()));
     auto session = cetl::get<UniquePtr<IRequestRxSession>>(std::move(maybe_session));
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         session.reset();
     });

--- a/test/unittest/transport/udp/test_udp_transport.cpp
+++ b/test/unittest/transport/udp/test_udp_transport.cpp
@@ -13,7 +13,6 @@
 #include "tx_rx_sockets_mock.hpp"
 
 #include <cetl/pf17/cetlpf.hpp>
-#include <cetl/rtti.hpp>
 #include <libcyphal/executor.hpp>
 #include <libcyphal/transport/errors.hpp>
 #include <libcyphal/transport/msg_sessions.hpp>
@@ -235,17 +234,17 @@ TEST_F(TestUpdTransport, setLocalNodeId)
 {
     auto transport = makeTransport({mr_});
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_THAT(transport->setLocalNodeId(UDPARD_NODE_ID_MAX + 1), Optional(testing::A<ArgumentError>()));
         EXPECT_THAT(transport->getLocalNodeId(), Eq(cetl::nullopt));
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         EXPECT_THAT(transport->setLocalNodeId(UDPARD_NODE_ID_MAX), Eq(cetl::nullopt));
         EXPECT_THAT(transport->getLocalNodeId(), Optional(UDPARD_NODE_ID_MAX));
     });
-    scheduler_.scheduleAt(3s, [&](const TimePoint) {
+    scheduler_.scheduleAt(3s, [&](const auto&) {
         //
         EXPECT_THAT(rx_socket_mock_.getEndpoint().ip_address, 0);
         EXPECT_THAT(rx_socket_mock_.getEndpoint().udp_port, 0);
@@ -253,7 +252,7 @@ TEST_F(TestUpdTransport, setLocalNodeId)
         EXPECT_THAT(transport->setLocalNodeId(UDPARD_NODE_ID_MAX), Eq(cetl::nullopt));
         EXPECT_THAT(transport->getLocalNodeId(), Optional(UDPARD_NODE_ID_MAX));
     });
-    scheduler_.scheduleAt(4s, [&](const TimePoint) {
+    scheduler_.scheduleAt(4s, [&](const auto&) {
         //
         EXPECT_THAT(transport->setLocalNodeId(0), Optional(testing::A<ArgumentError>()));
         EXPECT_THAT(transport->getLocalNodeId(), Optional(UDPARD_NODE_ID_MAX));
@@ -311,10 +310,10 @@ TEST_F(TestUpdTransport, makeMessageRxSession)
 {
     auto transport = makeTransport({mr_});
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
-        EXPECT_CALL(rx_socket_mock_, registerCallback(_, _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {      //
+        EXPECT_CALL(rx_socket_mock_, registerCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerCallback(std::move(function));
             }));
 
@@ -334,7 +333,7 @@ TEST_F(TestUpdTransport, makeMessageRxSession_invalid_subject_id)
 {
     auto transport = makeTransport({mr_});
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         auto maybe_rx_session = transport->makeMessageRxSession({0, UDPARD_SUBJECT_ID_MAX + 1});
         EXPECT_THAT(maybe_rx_session, VariantWith<AnyFailure>(VariantWith<ArgumentError>(_)));
@@ -348,10 +347,10 @@ TEST_F(TestUpdTransport, makeMessageRxSession_invalid_resubscription)
 
     const PortId test_subject_id = 111;
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
-        EXPECT_CALL(rx_socket_mock_, registerCallback(_, _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {      //
+        EXPECT_CALL(rx_socket_mock_, registerCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerCallback(std::move(function));
             }));
         auto maybe_rx_session1 = transport->makeMessageRxSession({0, test_subject_id});
@@ -360,10 +359,10 @@ TEST_F(TestUpdTransport, makeMessageRxSession_invalid_resubscription)
         auto maybe_rx_session2 = transport->makeMessageRxSession({0, test_subject_id});
         EXPECT_THAT(maybe_rx_session2, VariantWith<AnyFailure>(VariantWith<AlreadyExistsError>(_)));
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
-        EXPECT_CALL(rx_socket_mock_, registerCallback(_, _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {      //
+        EXPECT_CALL(rx_socket_mock_, registerCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerCallback(std::move(function));
             }));
         auto maybe_rx_session2 = transport->makeMessageRxSession({0, test_subject_id});
@@ -378,7 +377,7 @@ TEST_F(TestUpdTransport, makeRequestRxSession_invalid_resubscription)
 
     const PortId test_subject_id = 111;
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         auto maybe_rx_session1 = transport->makeRequestRxSession({0, test_subject_id});
         ASSERT_THAT(maybe_rx_session1, VariantWith<UniquePtr<IRequestRxSession>>(NotNull()));
@@ -386,7 +385,7 @@ TEST_F(TestUpdTransport, makeRequestRxSession_invalid_resubscription)
         auto maybe_rx_session2 = transport->makeRequestRxSession({0, test_subject_id});
         EXPECT_THAT(maybe_rx_session2, VariantWith<AnyFailure>(VariantWith<AlreadyExistsError>(_)));
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         auto maybe_rx_session2 = transport->makeRequestRxSession({0, test_subject_id});
         ASSERT_THAT(maybe_rx_session2, VariantWith<UniquePtr<IRequestRxSession>>(NotNull()));
@@ -400,7 +399,7 @@ TEST_F(TestUpdTransport, makeResponseRxSession_invalid_resubscription)
 
     const PortId test_subject_id = 111;
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         auto maybe_rx_session1 = transport->makeResponseRxSession({0, test_subject_id, 0x31});
         ASSERT_THAT(maybe_rx_session1, VariantWith<UniquePtr<IResponseRxSession>>(NotNull()));
@@ -408,7 +407,7 @@ TEST_F(TestUpdTransport, makeResponseRxSession_invalid_resubscription)
         auto maybe_rx_session2 = transport->makeResponseRxSession({0, test_subject_id, 0x31});
         EXPECT_THAT(maybe_rx_session2, VariantWith<AnyFailure>(VariantWith<AlreadyExistsError>(_)));
     });
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         auto maybe_rx_session2 = transport->makeResponseRxSession({0, test_subject_id, 0x31});
         ASSERT_THAT(maybe_rx_session2, VariantWith<UniquePtr<IResponseRxSession>>(NotNull()));
@@ -420,10 +419,10 @@ TEST_F(TestUpdTransport, makeXxxRxSession_all_with_same_port_id)
 {
     auto transport = makeTransport({mr_});
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
-        EXPECT_CALL(rx_socket_mock_, registerCallback(_, _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {      //
+        EXPECT_CALL(rx_socket_mock_, registerCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerCallback(std::move(function));
             }));
         const PortId test_port_id              = 111;
@@ -443,7 +442,7 @@ TEST_F(TestUpdTransport, makeMessageTxSession)
 {
     auto transport = makeTransport({mr_});
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         auto maybe_tx_session = transport->makeMessageTxSession({123});
         ASSERT_THAT(maybe_tx_session, VariantWith<UniquePtr<IMessageTxSession>>(NotNull()));
@@ -465,7 +464,7 @@ TEST_F(TestUpdTransport, sending_multiframe_payload_should_fail_for_anonymous)
     const auto       payload = makeIotaArray<UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME + 1>(b('0'));
     TransferMetadata metadata{0x13, {}, Priority::Nominal};
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         metadata.timestamp = now();
         auto failure       = session->send(metadata, makeSpansFrom(payload));
@@ -489,7 +488,7 @@ TEST_F(TestUpdTransport, sending_multiframe_payload_for_non_anonymous)
     const auto       payload = makeIotaArray<UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME + 1>(b('0'));
     TransferMetadata metadata{0x13, {}, Priority::Nominal};
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(tx_socket_mock_, send(_, _, _, _))
             .WillOnce([&](auto deadline, auto endpoint, auto, auto fragments) {
@@ -500,8 +499,8 @@ TEST_F(TestUpdTransport, sending_multiframe_payload_for_non_anonymous)
                 EXPECT_THAT(fragments[0], SizeIs(24 + UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME + 4));
                 return ITxSocket::SendResult::Success{true /* is_accepted */};
             });
-        EXPECT_CALL(tx_socket_mock_, registerCallback(_, _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {      //
+        EXPECT_CALL(tx_socket_mock_, registerCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("", now() + 10us, std::move(function));
             }));
 
@@ -509,7 +508,7 @@ TEST_F(TestUpdTransport, sending_multiframe_payload_for_non_anonymous)
         auto failure       = session->send(metadata, makeSpansFrom(payload));
         EXPECT_THAT(failure, Eq(cetl::nullopt));
     });
-    scheduler_.scheduleAt(1s + 10us, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s + 10us, [&](const auto&) {
         //
         EXPECT_CALL(tx_socket_mock_, send(_, _, _, _))
             .WillOnce([&](auto deadline, auto endpoint, auto, auto fragments) {
@@ -547,7 +546,7 @@ TEST_F(TestUpdTransport, send_multiframe_payload_to_redundant_not_ready_media)
     const auto       payload = makeIotaArray<UDPARD_MTU_DEFAULT>(b('0'));
     TransferMetadata metadata{0x13, {}, Priority::Nominal};
 
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         // Emulate once that the first media is not ready to send fragment. So transport will switch to
         // the second media, and will retry with the 1st only when its socket is ready @ +20us.
@@ -561,8 +560,8 @@ TEST_F(TestUpdTransport, send_multiframe_payload_to_redundant_not_ready_media)
                 EXPECT_THAT(fragments[0], SizeIs(24 + UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME + 4));  // 1st frame
                 return ITxSocket::SendResult::Success{false /* is_accepted */};
             });
-        EXPECT_CALL(tx_socket_mock_, registerCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                    //
+        EXPECT_CALL(tx_socket_mock_, registerCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("tx1", now() + 20us, std::move(function));
             }));
         EXPECT_CALL(tx_socket_mock2, send(_, _, _, _))
@@ -574,8 +573,8 @@ TEST_F(TestUpdTransport, send_multiframe_payload_to_redundant_not_ready_media)
                 EXPECT_THAT(fragments[0], SizeIs(24 + UDPARD_MTU_DEFAULT_MAX_SINGLE_FRAME + 4));  // 1st frame
                 return ITxSocket::SendResult::Success{true /* is_accepted */};
             });
-        EXPECT_CALL(tx_socket_mock2, registerCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                    //
+        EXPECT_CALL(tx_socket_mock2, registerCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("tx2", now() + 10us, std::move(function));
             }));
 
@@ -583,7 +582,7 @@ TEST_F(TestUpdTransport, send_multiframe_payload_to_redundant_not_ready_media)
         auto failure       = session->send(metadata, makeSpansFrom(payload));
         EXPECT_THAT(failure, Eq(cetl::nullopt));
     });
-    scheduler_.scheduleAt(1s + 10us, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s + 10us, [&](const auto&) {
         //
         EXPECT_CALL(tx_socket_mock2, send(_, _, _, _))
             .WillOnce([&](auto deadline, auto endpoint, auto, auto fragments) {
@@ -597,7 +596,7 @@ TEST_F(TestUpdTransport, send_multiframe_payload_to_redundant_not_ready_media)
                 return ITxSocket::SendResult::Success{true /* is_accepted */};
             });
     });
-    scheduler_.scheduleAt(1s + 20us, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s + 20us, [&](const auto&) {
         //
         EXPECT_CALL(tx_socket_mock_, send(_, _, _, _))
             .WillOnce([&](auto deadline, auto endpoint, auto, auto fragments) {
@@ -611,7 +610,7 @@ TEST_F(TestUpdTransport, send_multiframe_payload_to_redundant_not_ready_media)
                 return ITxSocket::SendResult::Success{true /* is_accepted */};
             });
     });
-    scheduler_.scheduleAt(1s + 20us + 5us, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s + 20us + 5us, [&](const auto&) {
         //
         EXPECT_CALL(tx_socket_mock_, send(_, _, _, _))
             .WillOnce([&](auto deadline, auto endpoint, auto, auto fragments) {
@@ -638,7 +637,6 @@ TEST_F(TestUpdTransport, send_payload_to_redundant_fallible_media)
         return libcyphal::detail::makeUniquePtr<TxSocketMock::ReferenceWrapper::Spec>(mr_, tx_socket_mock2);
     }));
 
-
     auto transport = makeTransport({mr_}, &media_mock2);
 
     StrictMock<TransientErrorHandlerMock> handler_mock;
@@ -656,7 +654,7 @@ TEST_F(TestUpdTransport, send_payload_to_redundant_fallible_media)
     TransferMetadata metadata{0x13, {}, Priority::Nominal};
 
     // 1. First attempt to send payload.
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         // Socket #0 failed to send, but not socket #2 - its frame should be dropped (but not for #2).
         //
@@ -680,8 +678,8 @@ TEST_F(TestUpdTransport, send_payload_to_redundant_fallible_media)
                 EXPECT_THAT(fragments[0], SizeIs(24 + 6 + 4));
                 return ITxSocket::SendResult::Success{true /* is_accepted */};
             });
-        EXPECT_CALL(tx_socket_mock2, registerCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                    //
+        EXPECT_CALL(tx_socket_mock2, registerCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("", now() + 20us, std::move(function));
             }));
 
@@ -689,14 +687,14 @@ TEST_F(TestUpdTransport, send_payload_to_redundant_fallible_media)
         EXPECT_THAT(session->send(metadata, makeSpansFrom(payload)), Eq(cetl::nullopt));
     });
     // 2. Second attempt to send payload (while 1st attempt still in progress for socket 2).
-    scheduler_.scheduleAt(1s + 10us, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s + 10us, [&](const auto&) {
         //
         // Socket #0 is fine but Socket #2 failed to send - its frame should be dropped (but not for #0).
         //
         EXPECT_CALL(tx_socket_mock_, send(_, _, _, _))
             .WillOnce(Return(ITxSocket::SendResult::Success{true /* is_accepted */}));
-        EXPECT_CALL(tx_socket_mock_, registerCallback(Ref(scheduler_), _))  //
-            .WillOnce(Invoke([&](auto&, auto function) {                    //
+        EXPECT_CALL(tx_socket_mock_, registerCallback(_))  //
+            .WillOnce(Invoke([&](auto function) {          //
                 return scheduler_.registerAndScheduleNamedCallback("", now() + 5us, std::move(function));
             }));
         //
@@ -732,12 +730,12 @@ TEST_F(TestUpdTransport, no_adhoc_tx_sockets_creation_when_there_is_nothing_to_s
     UniquePtr<IMessageTxSession> tx_session;
 
     // 1. Nothing to send, so no need to create any TX sockets.
-    scheduler_.scheduleAt(1s, [&](const TimePoint) {
+    scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, makeTxSocket()).Times(0);
     });
     // 2. Still no need to create any TX sockets, even with a "passive, never sending" TX session alive
-    scheduler_.scheduleAt(2s, [&](const TimePoint) {
+    scheduler_.scheduleAt(2s, [&](const auto&) {
         //
         // One attempt still expected (b/c of the session creation), but not on every `transport::run`.
         EXPECT_CALL(media_mock_, makeTxSocket())  //
@@ -754,16 +752,3 @@ TEST_F(TestUpdTransport, no_adhoc_tx_sockets_creation_when_there_is_nothing_to_s
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
 
 }  // namespace
-
-namespace cetl
-{
-
-// Just random id: 96B4BFC0-FCDD-4804-9C0E-97566FD9BE42
-template <>
-constexpr type_id type_id_getter<MyPlatformError>() noexcept
-{
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
-    return {0x96, 0xB4, 0xBF, 0xC0, 0xFC, 0xDD, 0x48, 0x04, 0x9C, 0x0E, 0x97, 0x56, 0x6F, 0xD9, 0xBE, 0x42};
-}
-
-}  // namespace cetl

--- a/test/unittest/transport/udp/tx_rx_sockets_mock.hpp
+++ b/test/unittest/transport/udp/tx_rx_sockets_mock.hpp
@@ -69,10 +69,9 @@ public:
             return tx_socket_mock_.send(deadline, multicast_endpoint, dscp, payload_fragments);
         }
 
-        CETL_NODISCARD IExecutor::Callback::Any registerCallback(IExecutor&                      executor,
-                                                                 IExecutor::Callback::Function&& function) override
+        CETL_NODISCARD IExecutor::Callback::Any registerCallback(IExecutor::Callback::Function&& function) override
         {
-            return tx_socket_mock_.registerCallback(executor, std::move(function));
+            return tx_socket_mock_.registerCallback(std::move(function));
         }
 
     private:
@@ -114,10 +113,7 @@ public:
                  const PayloadFragments payload_fragments),
                 (override));
 
-    MOCK_METHOD(IExecutor::Callback::Any,
-                registerCallback,
-                (IExecutor & executor, IExecutor::Callback::Function&& function),
-                (override));
+    MOCK_METHOD(IExecutor::Callback::Any, registerCallback, (IExecutor::Callback::Function && function), (override));
 
 private:
     const std::string name_;
@@ -160,10 +156,9 @@ public:
             return rx_socket_mock_.receive();
         }
 
-        CETL_NODISCARD IExecutor::Callback::Any registerCallback(IExecutor&                      executor,
-                                                                 IExecutor::Callback::Function&& function) override
+        CETL_NODISCARD IExecutor::Callback::Any registerCallback(IExecutor::Callback::Function&& function) override
         {
-            return rx_socket_mock_.registerCallback(executor, std::move(function));
+            return rx_socket_mock_.registerCallback(std::move(function));
         }
 
     private:
@@ -201,10 +196,7 @@ public:
 
     MOCK_METHOD(ReceiveResult::Type, receive, (), (override));
 
-    MOCK_METHOD(IExecutor::Callback::Any,
-                registerCallback,
-                (IExecutor & executor, IExecutor::Callback::Function&& function),
-                (override));
+    MOCK_METHOD(IExecutor::Callback::Any, registerCallback, (IExecutor::Callback::Function && function), (override));
 
 private:
     const std::string name_;

--- a/test/unittest/virtual_time_scheduler.hpp
+++ b/test/unittest/virtual_time_scheduler.hpp
@@ -32,7 +32,11 @@ public:
     void scheduleAt(const TimePoint exec_time, Callback::Function&& function)
     {
         auto callback = registerCallback(std::move(function));
-        scheduleCallback(callback, Callback::Schedule::Once{exec_time});
+
+        const bool result = callback.schedule(Callback::Schedule::Once{exec_time});
+        (void) result;
+        CETL_DEBUG_ASSERT(result, "");
+
         callbacks_bag_.emplace_back(std::move(callback));
     }
 
@@ -66,8 +70,8 @@ public:
 
     CETL_NODISCARD Callback::Any registerNamedCallback(const std::string& name, Callback::Function&& function)
     {
-        auto callback           = registerCallback(std::move(function));
-        named_cb_handles_[name] = callbackToHandle(callback);
+        auto callback              = registerCallback(std::move(function));
+        named_cb_interfaces_[name] = callback.getInterface();
         return callback;
     }
     void scheduleNamedCallback(const std::string& name)
@@ -80,7 +84,9 @@ public:
     }
     void scheduleNamedCallback(const std::string& name, const Callback::Schedule::Variant& schedule)
     {
-        scheduleCallbackByHandle(named_cb_handles_.at(name), schedule);
+        const bool result = named_cb_interfaces_.at(name)->schedule(schedule);
+        (void) result;
+        CETL_DEBUG_ASSERT(result, "");
     }
     CETL_NODISCARD Callback::Any registerAndScheduleNamedCallback(const std::string&   name,
                                                                   const TimePoint      time_point,
@@ -93,12 +99,16 @@ public:
                                                                   Callback::Function&&               function)
     {
         auto callback = registerNamedCallback(name, std::move(function));
-        scheduleCallback(callback, schedule);
+
+        const bool result = callback.schedule(schedule);
+        (void) result;
+        CETL_DEBUG_ASSERT(result, "");
+
         return callback;
     }
     CETL_NODISCARD bool hasNamedCallback(const std::string& name)
     {
-        return named_cb_handles_.find(name) != named_cb_handles_.end();
+        return named_cb_interfaces_.find(name) != named_cb_interfaces_.end();
     }
 
     // MARK: - IExecutor
@@ -109,33 +119,42 @@ public:
     }
 
 protected:
-    void onCallbackHandling(const Callback::Handle old_handle, const Callback::Handle new_handle) noexcept override
+    void onCallbackHandling(const CallbackHandling::Variant& event_var) override
     {
-        // Keep named callbacks up-to-date.
-        //
-        auto it = named_cb_handles_.begin();
-        while (it != named_cb_handles_.end())
+        cetl::visit([this](const auto& event) { onCallbackHandlingImpl(event); }, event_var);
+    }
+
+private:
+    void onCallbackHandlingImpl(const CallbackHandling::Moved& moved)
+    {
+        auto it = named_cb_interfaces_.begin();
+        while (it != named_cb_interfaces_.end())
         {
-            if (it->second == old_handle)
+            if (it->second == moved.old_interface)
             {
-                if (new_handle)
-                {
-                    it->second = new_handle;
-                }
-                else
-                {
-                    it = named_cb_handles_.erase(it);
-                    continue;
-                }
+                it->second = moved.new_interface;
             }
             ++it;
         }
     }
 
-private:
-    TimePoint                               now_;
-    std::vector<Callback::Any>              callbacks_bag_;
-    std::map<std::string, Callback::Handle> named_cb_handles_;
+    void onCallbackHandlingImpl(const CallbackHandling::Removed& removed)
+    {
+        auto it = named_cb_interfaces_.begin();
+        while (it != named_cb_interfaces_.end())
+        {
+            if (it->second == removed.old_interface)
+            {
+                it = named_cb_interfaces_.erase(it);
+                continue;
+            }
+            ++it;
+        }
+    }
+
+    TimePoint                                   now_;
+    std::vector<Callback::Any>                  callbacks_bag_;
+    std::map<std::string, Callback::Interface*> named_cb_interfaces_;
 
 };  // VirtualTimeScheduler
 

--- a/test/unittest/virtual_time_scheduler.hpp
+++ b/test/unittest/virtual_time_scheduler.hpp
@@ -32,11 +32,7 @@ public:
     void scheduleAt(const TimePoint exec_time, Callback::Function&& function)
     {
         auto callback = registerCallback(std::move(function));
-
-        const bool result = callback.schedule(Callback::Schedule::Once{exec_time});
-        (void) result;
-        CETL_DEBUG_ASSERT(result, "");
-
+        callback.schedule(Callback::Schedule::Once{exec_time});
         callbacks_bag_.emplace_back(std::move(callback));
     }
 
@@ -84,9 +80,7 @@ public:
     }
     void scheduleNamedCallback(const std::string& name, const Callback::Schedule::Variant& schedule)
     {
-        const bool result = named_cb_interfaces_.at(name)->schedule(schedule);
-        (void) result;
-        CETL_DEBUG_ASSERT(result, "");
+        named_cb_interfaces_.at(name)->schedule(schedule);
     }
     CETL_NODISCARD Callback::Any registerAndScheduleNamedCallback(const std::string&   name,
                                                                   const TimePoint      time_point,
@@ -99,11 +93,7 @@ public:
                                                                   Callback::Function&&               function)
     {
         auto callback = registerNamedCallback(name, std::move(function));
-
-        const bool result = callback.schedule(schedule);
-        (void) result;
-        CETL_DEBUG_ASSERT(result, "");
-
+        callback.schedule(schedule);
         return callback;
     }
     CETL_NODISCARD bool hasNamedCallback(const std::string& name)


### PR DESCRIPTION
Fixes for issues #372 & #373.

- Callback changes:
  - Eliminated `Callback::Schedule::None` alternative. Optional schedule now is stored instead.
  - Added new `Callback::Arg` struct - parameter of the `Callback::Function`. Contains:
    - `exec_time` - scheduled execution time of the callback
    - `approx_now` - actual (approximated) time of the execution
  - Introduced `Callback::Interface`
    - has `bool schedule(const Schedule::Variant&)` method.
- `IExecutor` changes:
  - Removed `scheduleCallback` method. Now scheduling done via callback interface.
- `SingleThreadedExecutor` (and its derived `PosixSingleThreadedExecutor`) don't rely anymore on unsafe `Callback::Handle` and `reinterpret_cast`-s. Strong typed `Callback::Interface` is in use instead.

Also:
- simplified RTTI usage (give up usage of `cetl::rtti_helper` which is not really helpful)
- other minor fixes (based on previous PR review notes)
- latest toolshed v 22.4.8

Coverage:
![Screenshot from 2024-08-12 12-22-13](https://github.com/user-attachments/assets/d9ebf5ca-beef-4e3f-9f61-98575c7f60e5)
