### PR TITLE
Apply small payload deserialize optimization

### DIFF
--- a/include/libcyphal/presentation/common_helpers.hpp
+++ b/include/libcyphal/presentation/common_helpers.hpp
@@ -43,6 +43,8 @@ static cetl::optional<DeserializationFailure> tryDeserializePayload(const transp
     //
     if (payload.size() <= SmallPayloadSize)
     {
+        // Next nolint b/c we initialize buffer with payload copying.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
         std::array<std::uint8_t, SmallPayloadSize> small_buffer;
         const auto                                 data_size = payload.copy(0, small_buffer.data(), payload.size());
         const nunavut::support::const_bitspan      bitspan{small_buffer.data(), data_size};

--- a/test/unittest/presentation/test_client.cpp
+++ b/test/unittest/presentation/test_client.cpp
@@ -523,6 +523,8 @@ TEST_F(TestClient, request_response_failures)
     });
     scheduler_.scheduleAt(4s, [&](const auto&) {
         //
+        using libcyphal::presentation::detail::SmallPayloadSize;
+
         EXPECT_CALL(state.req_tx_session_mock_, send(_, _)).WillOnce(Return(cetl::nullopt));
 
         auto maybe_promise = client.request(now() + 100ms, Service::Request{mr_alloc_});
@@ -530,8 +532,8 @@ TEST_F(TestClient, request_response_failures)
         response_promise.emplace(cetl::get<SvcResPromise>(std::move(maybe_promise)));
 
         // Emulate that there is no memory available for the response deserialization.
-        EXPECT_CALL(storage_mock, size()).WillRepeatedly(Return(123));
-        EXPECT_CALL(mr_mock, do_allocate(123, _)).WillOnce(Return(nullptr));
+        EXPECT_CALL(storage_mock, size()).WillRepeatedly(Return(SmallPayloadSize + 1));
+        EXPECT_CALL(mr_mock, do_allocate(SmallPayloadSize + 1, _)).WillOnce(Return(nullptr));
         ScatteredBufferStorageMock::Wrapper storage{&storage_mock};
 
         ServiceRxTransfer transfer{{{{transfer_id + 0, Priority::Nominal}, now()}, 0x31},

--- a/test/unittest/presentation/test_client.cpp
+++ b/test/unittest/presentation/test_client.cpp
@@ -18,6 +18,7 @@
 #include <cetl/pf17/cetlpf.hpp>
 #include <libcyphal/errors.hpp>
 #include <libcyphal/presentation/client.hpp>
+#include <libcyphal/presentation/common_helpers.hpp>
 #include <libcyphal/presentation/presentation.hpp>
 #include <libcyphal/presentation/response_promise.hpp>
 #include <libcyphal/transport/errors.hpp>

--- a/test/unittest/presentation/test_server.cpp
+++ b/test/unittest/presentation/test_server.cpp
@@ -16,6 +16,7 @@
 
 #include <cetl/pf17/cetlpf.hpp>
 #include <libcyphal/errors.hpp>
+#include <libcyphal/presentation/common_helpers.hpp>
 #include <libcyphal/presentation/presentation.hpp>
 #include <libcyphal/presentation/server.hpp>
 #include <libcyphal/transport/errors.hpp>

--- a/test/unittest/presentation/test_server.cpp
+++ b/test/unittest/presentation/test_server.cpp
@@ -272,9 +272,11 @@ TEST_F(TestServer, service_request_response_failures)
     });
     scheduler_.scheduleAt(2s, [&](const auto&) {
         //
+        using libcyphal::presentation::detail::SmallPayloadSize;
+
         // Emulate that there is no memory available for the request deserialization.
-        EXPECT_CALL(storage_mock, size()).WillRepeatedly(Return(123));
-        EXPECT_CALL(mr_mock, do_allocate(123, _)).WillOnce(Return(nullptr));
+        EXPECT_CALL(storage_mock, size()).WillRepeatedly(Return(SmallPayloadSize + 1));
+        EXPECT_CALL(mr_mock, do_allocate(SmallPayloadSize + 1, _)).WillOnce(Return(nullptr));
         ScatteredBufferStorageMock::Wrapper storage{&storage_mock};
 
         ServiceRxTransfer request{{{{123, Priority::Fast}, now()}, NodeId{0x31}}, ScatteredBuffer{std::move(storage)}};

--- a/test/unittest/presentation/test_subscriber.cpp
+++ b/test/unittest/presentation/test_subscriber.cpp
@@ -15,6 +15,7 @@
 #include "virtual_time_scheduler.hpp"
 
 #include <cetl/pf17/cetlpf.hpp>
+#include <libcyphal/presentation/common_helpers.hpp>
 #include <libcyphal/presentation/presentation.hpp>
 #include <libcyphal/presentation/subscriber.hpp>
 #include <libcyphal/transport/msg_sessions.hpp>
@@ -264,7 +265,7 @@ TEST_F(TestSubscriber, onReceive_deserialize_failure)
 
     NiceMock<ScatteredBufferStorageMock> storage_mock;
     ScatteredBufferStorageMock::Wrapper  storage{&storage_mock};
-    EXPECT_CALL(storage_mock, size()).WillRepeatedly(Return(Message::_traits_::SerializationBufferSizeBytes));
+    EXPECT_CALL(storage_mock, size()).WillRepeatedly(Return(libcyphal::presentation::detail::SmallPayloadSize + 1));
     EXPECT_CALL(storage_mock, copy(_, _, _))                           //
         .WillRepeatedly(Invoke([&](auto, auto* const dst, auto len) {  //
             //

--- a/test/unittest/presentation/test_subscriber.cpp
+++ b/test/unittest/presentation/test_subscriber.cpp
@@ -293,9 +293,11 @@ TEST_F(TestSubscriber, onReceive_deserialize_failure)
     });
     scheduler_.scheduleAt(2s, [&](const auto&) {
         //
+        using libcyphal::presentation::detail::SmallPayloadSize;
+
         // Fix "problem" with the bad array size,
         // but introduce another one with memory allocation.
-        EXPECT_CALL(storage_mock, size()).WillRepeatedly(Return(1));
+        EXPECT_CALL(storage_mock, size()).WillRepeatedly(Return(SmallPayloadSize + 1));
         EXPECT_CALL(storage_mock, copy(_, _, _))                           //
             .WillRepeatedly(Invoke([&](auto, auto* const dst, auto len) {  //
                 //
@@ -304,7 +306,7 @@ TEST_F(TestSubscriber, onReceive_deserialize_failure)
                 (void) std::memmove(dst, buffer.data(), size);
                 return size;
             }));
-        EXPECT_CALL(mr_mock, do_allocate(1, _)).WillRepeatedly(Return(nullptr));
+        EXPECT_CALL(mr_mock, do_allocate(SmallPayloadSize + 1, _)).WillRepeatedly(Return(nullptr));
         //
         transfer.metadata.rx_meta.base.transfer_id++;
         transfer.metadata.rx_meta.timestamp = now();


### PR DESCRIPTION
This case (namely with zero-length payload) was discovered during my work with the demo app, where I deliberately use special (O1Heap-based) PMR allocator for ALL dynamic allocations.
It turns out that such allocator has special/corner case when payload is empty (which is a totally valid case, f.e. for an RPC service request). So, investigation of this problem also brought attention to quite useful optimization we can have during deserialization.