### PR TITLE
Defined `platform::storage::IKeyValue` interface

### DIFF
--- a/docs/examples/platform/storage.hpp
+++ b/docs/examples/platform/storage.hpp
@@ -1,0 +1,120 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef EXAMPLE_PLATFORM_STORAGE_HPP_INCLUDED
+#define EXAMPLE_PLATFORM_STORAGE_HPP_INCLUDED
+
+#include <cetl/pf17/cetlpf.hpp>
+#include <cetl/pf20/cetlpf.hpp>
+#include <libcyphal/platform/storage.hpp>
+#include <libcyphal/types.hpp>
+
+#include <cerrno>
+#include <cstddef>
+#include <fstream>
+#include <stdio.h>
+#include <string>
+#include <string_view>
+#include <sys/stat.h>
+#include <utility>
+
+namespace example
+{
+namespace platform
+{
+namespace storage
+{
+
+class KeyValue final : public libcyphal::platform::storage::IKeyValue
+{
+public:
+    KeyValue(std::string root_path)
+        : root_path_{std::move(root_path)}
+    {
+        if ((mkdir(root_path_.c_str(), 0755) != 0) && (errno != EEXIST))
+        {
+            std::cerr << "Error making folder: '" << root_path_ << "'.\n";
+            std::cerr << "Error: " << std::strerror(errno) << std::endl;
+        }
+    }
+
+private:
+    using Error = libcyphal::platform::storage::Error;
+
+    std::string makeFilePath(const cetl::string_view key) const
+    {
+        return root_path_ + "/" + std::string{key.cbegin(), key.cend()};
+    }
+
+    // MARK: - libcyphal::platform::storage::IKeyValue
+
+    auto get(const cetl::string_view        key,
+             const cetl::span<std::uint8_t> data) const -> libcyphal::Expected<std::size_t, Error> override
+    {
+        const auto    file_path = makeFilePath(key);
+        std::ifstream file{file_path, std::ios::in | std::ios::binary | std::ios::ate};
+        if (!file)
+        {
+            return Error::Existence;
+        }
+
+        const auto data_size =
+            std::min(static_cast<std::streamsize>(file.tellg()), static_cast<std::streamsize>(data.size()));
+        file.seekg(0);
+        file.read(reinterpret_cast<char*>(data.data()), data_size);
+        if (!file)
+        {
+            std::cerr << "Error reading file: '" << file_path << "'.\n";
+            std::cerr << "Error: " << std::strerror(errno) << std::endl;
+            return Error::IO;
+        }
+
+        return static_cast<std::size_t>(file.gcount());
+    }
+
+    auto put(const cetl::string_view key, const cetl::span<const std::uint8_t> data)  //
+        -> cetl::optional<Error> override
+    {
+        const auto    file_path = makeFilePath(key);
+        std::ofstream file{file_path, std::ios::out | std::ios::binary};
+        if (!file)
+        {
+            std::cerr << "Error opening file: '" << file_path << "'.\n";
+            std::cerr << "Error: " << std::strerror(errno) << std::endl;
+            return Error::IO;
+        }
+
+        file.write(reinterpret_cast<const char*>(data.data()), static_cast<std::streamsize>(data.size()));
+        if (!file)
+        {
+            std::cerr << "Error writing to file: '" << file_path << "'.\n";
+            std::cerr << "Error: " << std::strerror(errno) << std::endl;
+            return Error::IO;
+        }
+
+        return cetl::nullopt;
+    }
+
+    auto drop(const cetl::string_view key) -> cetl::optional<Error> override
+    {
+        const auto file_path = makeFilePath(key);
+        if ((std::remove(file_path.c_str()) != 0) && (errno != ENOENT))
+        {
+            std::cerr << "Error removing file: '" << file_path << "'.\n";
+            std::cerr << "Error: " << std::strerror(errno) << std::endl;
+            return Error::IO;
+        }
+        return cetl::nullopt;
+    }
+
+    const std::string root_path_;
+
+};  // KeyValue
+
+}  // namespace storage
+}  // namespace platform
+}  // namespace example
+
+#endif  // EXAMPLE_PLATFORM_STORAGE_HPP_INCLUDED

--- a/docs/examples/platform/storage.hpp
+++ b/docs/examples/platform/storage.hpp
@@ -43,6 +43,9 @@ public:
 private:
     using Error = libcyphal::platform::storage::Error;
 
+    /// In practice, the keys could be hashed, so it won't be necessary to deal with directory nesting.
+    /// This is fine b/c we don't need key listing, and so we don't have to retain the key names.
+    ///
     std::string makeFilePath(const cetl::string_view key) const
     {
         return root_path_ + "/" + std::string{key.cbegin(), key.cend()};

--- a/docs/examples/platform/storage.hpp
+++ b/docs/examples/platform/storage.hpp
@@ -14,9 +14,9 @@
 #include <cerrno>
 #include <cstddef>
 #include <fstream>
+#include <iostream>
 #include <stdio.h>
 #include <string>
-#include <string_view>
 #include <sys/stat.h>
 #include <utility>
 

--- a/docs/examples/platform/storage.hpp
+++ b/docs/examples/platform/storage.hpp
@@ -30,7 +30,7 @@ namespace storage
 class KeyValue final : public libcyphal::platform::storage::IKeyValue
 {
 public:
-    KeyValue(std::string root_path)
+    explicit KeyValue(std::string root_path)
         : root_path_{std::move(root_path)}
     {
         if ((mkdir(root_path_.c_str(), 0755) != 0) && (errno != EEXIST))

--- a/include/libcyphal/application/registry/registry_impl.hpp
+++ b/include/libcyphal/application/registry/registry_impl.hpp
@@ -225,6 +225,8 @@ inline auto load(const platform::storage::IKeyValue& kv, IIntrospectableRegistry
             // as it is not incompatible with the protocol.
             if (reg_meta->flags.persistent)
             {
+                // Next nolint b/c we initialize buffer with `kv.get` call.
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
                 std::array<std::uint8_t, IRegister::Value::_traits_::SerializationBufferSizeBytes> buffer;
                 const auto kv_get_result = kv.get(reg_name, {buffer.data(), buffer.size()});
                 (void) kv_get_result;
@@ -288,6 +290,8 @@ auto save(platform::storage::IKeyValue&  kv,
             {
                 // We don't expect to have any serialization errors here,
                 // b/c `SerializationBufferSizeBytes` sized buffer should always be big enough.
+                // Next nolint b/c we use a buffer to serialize the message, so no need to zero it.
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
                 std::array<std::uint8_t, IRegister::Value::_traits_::SerializationBufferSizeBytes> buffer;
                 const auto buffer_size = serialize(reg_meta->value, buffer);
                 CETL_DEBUG_ASSERT(buffer_size.has_value(), "");

--- a/include/libcyphal/platform/storage.hpp
+++ b/include/libcyphal/platform/storage.hpp
@@ -29,7 +29,7 @@ enum class Error : std::uint8_t
     API,        ///< Bad API invocation (e.g., null pointer).
     Capacity,   ///< No space left on the storage device.
     IO,         ///< Device input/output error.
-    Internal,   ///< Internal failure in the filesystem (storage corruption or logic error).
+    Internal,   ///< Internal failure in the storage implementation (storage corruption or logic error).
 
 };  // Error
 
@@ -62,7 +62,6 @@ public:
     /// Store data under a key.
     ///
     /// Existing data, if any, is replaced entirely.
-    /// New file and its parent directories created implicitly.
     /// Either all or none of the data bytes are written.
     ///
     /// @param key The key of the value to store.

--- a/include/libcyphal/platform/storage.hpp
+++ b/include/libcyphal/platform/storage.hpp
@@ -1,0 +1,94 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef LIBCYPHAL_PLATFORM_STORAGE_HPP_INCLUDED
+#define LIBCYPHAL_PLATFORM_STORAGE_HPP_INCLUDED
+
+#include "libcyphal/types.hpp"
+
+#include <cetl/pf17/cetlpf.hpp>
+#include <cetl/pf20/cetlpf.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace libcyphal
+{
+namespace platform
+{
+namespace storage
+{
+
+/// Defines possible errors that can occur during storage operations.
+///
+enum class Error : std::uint8_t
+{
+    Existence,  ///< Entry does not exist but should; or exists but shouldn't.
+    API,        ///< Bad API invocation (e.g., null pointer).
+    Capacity,   ///< No space left on the storage device.
+    IO,         ///< Device input/output error.
+    Internal,   ///< Internal failure in the filesystem (storage corruption or logic error).
+
+};  // Error
+
+/// Defines interface of a very simple API for storing and retrieving named blobs.
+///
+/// The underlying storage implementation is required to be power-loss tolerant and to
+/// validate data integrity per key (e.g., using CRC and such).
+/// This interface is fully blocking and should only be used during initialization and shutdown,
+/// never during normal operation. Non-blocking adapters can be built on top of it.
+///
+class IKeyValue
+{
+public:
+    IKeyValue(IKeyValue&&)                 = delete;
+    IKeyValue(const IKeyValue&)            = delete;
+    IKeyValue& operator=(IKeyValue&&)      = delete;
+    IKeyValue& operator=(const IKeyValue&) = delete;
+
+    /// Retrieve data by a key.
+    ///
+    /// If the key does not exist, the `Error::Existence` is returned.
+    ///
+    /// @param key The key of the value to retrieve.
+    /// @param data The buffer to write the data to.
+    /// @return Either the number of bytes read or an error.
+    ///
+    virtual auto get(const cetl::string_view key, const cetl::span<std::uint8_t> data) const  //
+        -> Expected<std::size_t, Error> = 0;
+
+    /// Store data under a key.
+    ///
+    /// Existing data, if any, is replaced entirely.
+    /// New file and its parent directories created implicitly.
+    /// Either all or none of the data bytes are written.
+    ///
+    /// @param key The key of the value to store.
+    /// @param data The buffer to read the data from.
+    /// @return Either an error or nothing.
+    ///
+    virtual auto put(const cetl::string_view key, const cetl::span<const std::uint8_t> data)  //
+        -> cetl::optional<Error> = 0;
+
+    /// Remove data under a key.
+    ///
+    /// If the key does not exist, the existence error is returned.
+    ///
+    /// @param key The key of the value to remove.
+    /// @return Either an error or nothing.
+    ///
+    virtual auto drop(const cetl::string_view key) -> cetl::optional<Error> = 0;
+
+protected:
+    IKeyValue()  = default;
+    ~IKeyValue() = default;
+
+};  // IKeyValue
+
+}  // namespace storage
+}  // namespace platform
+}  // namespace libcyphal
+
+#endif  // LIBCYPHAL_PLATFORM_STORAGE_HPP_INCLUDED

--- a/test/unittest/application/registry/registry_gtest_helpers.hpp
+++ b/test/unittest/application/registry/registry_gtest_helpers.hpp
@@ -1,0 +1,157 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef LIBCYPHAL_APPLICATION_REGISTRY_GTEST_HELPERS_HPP_INCLUDED
+#define LIBCYPHAL_APPLICATION_REGISTRY_GTEST_HELPERS_HPP_INCLUDED
+
+#include <libcyphal/application/registry/registry.hpp>
+
+#include <uavcan/_register/Value_1_0.hpp>
+
+#include <gtest/gtest-matchers.h>
+#include <gtest/gtest-printers.h>
+
+#include <ostream>
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+
+namespace uavcan
+{
+namespace primitive
+{
+
+inline void PrintTo(const Empty_1_0&, std::ostream* os)
+{
+    *os << "Empty_1_0";
+}
+inline void PrintTo(const String_1_0& str, std::ostream* os)
+{
+    *os << "String_1_0{'" << cetl::string_view{reinterpret_cast<const char*>(str.value.data()), str.value.size()}
+        << "'}";
+    ;
+}
+inline void PrintTo(const Unstructured_1_0& data, std::ostream* os)
+{
+    *os << "Unstructured_1_0{cnt=" << data.value.size() << "}";
+}
+
+namespace array
+{
+
+inline void PrintTo(const Bit_1_0&, std::ostream* os)
+{
+    *os << "Bit_1_0[]";
+}
+inline void PrintTo(const Integer64_1_0&, std::ostream* os)
+{
+    *os << "Integer64_1_0[]";
+}
+inline void PrintTo(const Integer32_1_0&, std::ostream* os)
+{
+    *os << "Integer32_1_0[]";
+}
+inline void PrintTo(const Integer16_1_0&, std::ostream* os)
+{
+    *os << "Integer16_1_0[]";
+}
+inline void PrintTo(const Integer8_1_0&, std::ostream* os)
+{
+    *os << "Integer8_1_0[]";
+}
+inline void PrintTo(const Natural64_1_0&, std::ostream* os)
+{
+    *os << "Natural64_1_0[]";
+}
+inline void PrintTo(const Natural32_1_0&, std::ostream* os)
+{
+    *os << "Natural32_1_0[]";
+}
+inline void PrintTo(const Natural16_1_0&, std::ostream* os)
+{
+    *os << "Natural16_1_0[]";
+}
+inline void PrintTo(const Natural8_1_0&, std::ostream* os)
+{
+    *os << "Natural8_1_0[]";
+}
+inline void PrintTo(const Real64_1_0&, std::ostream* os)
+{
+    *os << "Real64_1_0[]";
+}
+inline void PrintTo(const Real32_1_0&, std::ostream* os)
+{
+    *os << "Real32_1_0[]";
+}
+inline void PrintTo(const Real16_1_0&, std::ostream* os)
+{
+    *os << "Real16_1_0[]";
+}
+
+}  // namespace array
+}  // namespace primitive
+
+namespace _register
+{
+
+inline void PrintTo(const Value_1_0& value, std::ostream* os)
+{
+    *os << "Value_1_0{";
+    cetl::visit([os](const auto& v) { PrintTo(v, os); }, value.union_value);
+    *os << "}";
+}
+
+}  // namespace _register
+}  // namespace uavcan
+
+namespace libcyphal
+{
+namespace application
+{
+namespace registry
+{
+
+// MARK: - GTest Printers:
+
+// MARK: - GTest Matchers:
+
+class RegisterValueMatcher
+{
+public:
+    using is_gtest_matcher = void;
+
+    explicit RegisterValueMatcher(const IRegister::Value& value)
+        : value_{value}
+    {
+    }
+
+    bool MatchAndExplain(const IRegister::Value& value, std::ostream*) const
+    {
+        return value_.union_value.index() == value.union_value.index();
+    }
+    void DescribeTo(std::ostream* os) const
+    {
+        *os << "is " << testing::PrintToString(value_);
+    }
+    void DescribeNegationTo(std::ostream* os) const
+    {
+        *os << "is NOT " << testing::PrintToString(value_);
+    }
+
+private:
+    const IRegister::Value value_;
+};
+inline testing::Matcher<const IRegister::Value&> RegisterValueEq(const IRegister::Value& value)
+{
+    return RegisterValueMatcher(value);
+
+}  // RegisterValueMatcher
+
+}  // namespace registry
+}  // namespace application
+}  // namespace libcyphal
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+
+#endif  // LIBCYPHAL_APPLICATION_REGISTRY_GTEST_HELPERS_HPP_INCLUDED

--- a/test/unittest/application/registry/test_registry.cpp
+++ b/test/unittest/application/registry/test_registry.cpp
@@ -319,7 +319,7 @@ TEST_F(TestRegistry, save)
 
         // Successful save.
         //
-        EXPECT_CALL(rgy_mock, size()).WillRepeatedly(Return(2));
+        EXPECT_CALL(rgy_mock, size()).WillOnce(Return(2));
         EXPECT_CALL(rgy_mock, index(0)).WillRepeatedly(Return("A"));
         EXPECT_CALL(rgy_mock, index(1)).WillRepeatedly(Return("B"));
         EXPECT_CALL(rgy_mock, get(IRegister::Name{"A"}))  // Emulate that 'A' is gone - should be skipped.
@@ -332,7 +332,7 @@ TEST_F(TestRegistry, save)
 
         // Failure save.
         //
-        EXPECT_CALL(rgy_mock, size()).WillRepeatedly(Return(1));
+        EXPECT_CALL(rgy_mock, size()).WillOnce(Return(1));
         EXPECT_CALL(rgy_mock, index(0)).WillRepeatedly(Return("A"));
         EXPECT_CALL(rgy_mock, get(IRegister::Name{"A"}))
             .WillOnce(Return(IRegister::ValueAndFlags{makeUInt8Value({0x42, 0xFE}), {true, true}}));
@@ -345,7 +345,7 @@ TEST_F(TestRegistry, save)
         const StrictMock<IntrospectableRegistryMock>           rgy_mock;
         StrictMock<libcyphal::platform::storage::KeyValueMock> key_value_mock;
 
-        EXPECT_CALL(rgy_mock, size()).WillRepeatedly(Return(3));
+        EXPECT_CALL(rgy_mock, size()).WillOnce(Return(3));
         EXPECT_CALL(rgy_mock, index(0)).WillRepeatedly(Return("A"));
         EXPECT_CALL(rgy_mock, index(1)).WillRepeatedly(Return("B"));
         EXPECT_CALL(rgy_mock, index(2)).WillRepeatedly(Return("C"));

--- a/test/unittest/application/registry/test_registry.cpp
+++ b/test/unittest/application/registry/test_registry.cpp
@@ -319,7 +319,7 @@ TEST_F(TestRegistry, load)
                 return 1UL;
             }));
         EXPECT_CALL(key_value_mock, get(IRegister::Name{"B"}, _))  //
-            .WillOnce(Return(4UL));
+            .WillOnce(Return(0UL));
         //
         EXPECT_CALL(rgy_mock, set(IRegister::Name{"A"}, RegisterValueEq(makeUInt8Value({}))))  //
             .WillOnce(Return(cetl::nullopt));

--- a/test/unittest/platform/storage_key_value_mock.hpp
+++ b/test/unittest/platform/storage_key_value_mock.hpp
@@ -1,0 +1,53 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef LIBCYPHAL_PLATFORM_STORAGE_KEY_VALUE_MOCK_HPP_INCLUDED
+#define LIBCYPHAL_PLATFORM_STORAGE_KEY_VALUE_MOCK_HPP_INCLUDED
+
+#include <cetl/pf17/cetlpf.hpp>
+#include <libcyphal/platform/storage.hpp>
+
+#include <gmock/gmock.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace libcyphal
+{
+namespace platform
+{
+namespace storage
+{
+
+class KeyValueMock : public IKeyValue
+{
+public:
+    KeyValueMock()          = default;
+    virtual ~KeyValueMock() = default;
+
+    KeyValueMock(const KeyValueMock&)                = delete;
+    KeyValueMock(KeyValueMock&&) noexcept            = delete;
+    KeyValueMock& operator=(const KeyValueMock&)     = delete;
+    KeyValueMock& operator=(KeyValueMock&&) noexcept = delete;
+
+    // MARK: IKeyValue
+
+    MOCK_METHOD((Expected<std::size_t, Error>),
+                get,
+                (const cetl::string_view key, const cetl::span<std::uint8_t> data),
+                (const, override));
+    MOCK_METHOD(cetl::optional<Error>,
+                put,
+                (const cetl::string_view key, const cetl::span<const std::uint8_t> data),
+                (override));
+    MOCK_METHOD(cetl::optional<Error>, drop, (const cetl::string_view key), (override));
+
+};  // KeyValueMock
+
+}  // namespace storage
+}  // namespace platform
+}  // namespace libcyphal
+
+#endif  // LIBCYPHAL_PLATFORM_STORAGE_KEY_VALUE_MOCK_HPP_INCLUDED


### PR DESCRIPTION
- Defined abstract key-value storage interface; plus its mock under unit tests.
- Added `load` & `save` methods for persisting registry in a storage; its unit test coverage (100%).
- Extended example_2_app_0 with registry persisting.