### PR TITLE
Set default PMR

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: get nunavut
         run: >
-          pip install git+https://github.com/OpenCyphal/nunavut.git@7f62204ddec9e5d4fbe4a969f9fcdfd5d045d35b
+          pip install git+https://github.com/OpenCyphal/nunavut.git@3.0.preview
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v2
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: get nunavut
         # TODO: setup a venv, cache, and distribute to the other jobs.
         run: >
-          pip install git+https://github.com/OpenCyphal/nunavut.git@7f62204ddec9e5d4fbe4a969f9fcdfd5d045d35b
+          pip install git+https://github.com/OpenCyphal/nunavut.git@3.0.preview
       - name: configure
         run: >
           ./build-tools/bin/verify.py
@@ -70,7 +70,7 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('cmake/modules/*.cmake') }}
     - name: get nunavut
       run: >
-        pip install git+https://github.com/OpenCyphal/nunavut.git@7f62204ddec9e5d4fbe4a969f9fcdfd5d045d35b
+        pip install git+https://github.com/OpenCyphal/nunavut.git@3.0.preview
     - name: run tests
       env:
         GTEST_COLOR: yes
@@ -115,7 +115,7 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('cmake/modules/*.cmake') }}
     - name: get nunavut
       run: >
-        pip install git+https://github.com/OpenCyphal/nunavut.git@7f62204ddec9e5d4fbe4a969f9fcdfd5d045d35b
+        pip install git+https://github.com/OpenCyphal/nunavut.git@3.0.preview
     - name: doc-gen
       run: >
         ./build-tools/bin/verify.py

--- a/docs/examples/0_transport/example_0_transport_1_heartbeat_getinfo_udp.cpp
+++ b/docs/examples/0_transport/example_0_transport_1_heartbeat_getinfo_udp.cpp
@@ -16,6 +16,7 @@
 #include "platform/posix/udp/udp_media.hpp"
 #include "platform/tracking_memory_resource.hpp"
 
+#include <cetl/pf17/cetlpf.hpp>
 #include <libcyphal/transport/types.hpp>
 #include <libcyphal/transport/udp/udp_transport.hpp>
 #include <libcyphal/types.hpp>
@@ -55,6 +56,8 @@ class Example_0_Transport_1_Heartbeat_GetInfo_Udp : public testing::Test
 protected:
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         // Duration in seconds for which the test will run. Default is 10 seconds.
         if (const auto* const run_duration_str = std::getenv("CYPHAL__RUN"))
         {

--- a/docs/examples/0_transport/example_0_transport_2_heartbeat_getinfo_linux_can.cpp
+++ b/docs/examples/0_transport/example_0_transport_2_heartbeat_getinfo_linux_can.cpp
@@ -16,6 +16,7 @@
 #include "platform/node_helpers.hpp"
 #include "platform/tracking_memory_resource.hpp"
 
+#include <cetl/pf17/cetlpf.hpp>
 #include <libcyphal/transport/can/can_transport.hpp>
 #include <libcyphal/transport/types.hpp>
 #include <libcyphal/types.hpp>
@@ -59,6 +60,8 @@ class Example_0_Transport_2_Heartbeat_GetInfo_Can : public testing::Test
 protected:
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         // Duration in seconds for which the test will run. Default is 10 seconds.
         if (const auto* const run_duration_str = std::getenv("CYPHAL__RUN"))
         {

--- a/docs/examples/1_presentation/example_1_presentation_0_hello_raw_pubsub_udp.cpp
+++ b/docs/examples/1_presentation/example_1_presentation_0_hello_raw_pubsub_udp.cpp
@@ -66,6 +66,8 @@ protected:
 
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         // Duration in seconds for which the test will run. Default is 10 seconds.
         if (const auto* const run_duration_str = std::getenv("CYPHAL__RUN"))
         {

--- a/docs/examples/1_presentation/example_1_presentation_1_ping_user_service_udp.cpp
+++ b/docs/examples/1_presentation/example_1_presentation_1_ping_user_service_udp.cpp
@@ -153,6 +153,8 @@ protected:
 
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         // Duration in seconds for which the test will run. Default is 10 seconds.
         if (const auto* const run_duration_str = std::getenv("CYPHAL__RUN"))
         {

--- a/docs/examples/1_presentation/example_1_presentation_2_heartbeat_getinfo_udp.cpp
+++ b/docs/examples/1_presentation/example_1_presentation_2_heartbeat_getinfo_udp.cpp
@@ -68,6 +68,8 @@ protected:
 
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         // Duration in seconds for which the test will run. Default is 10 seconds.
         if (const auto* const run_duration_str = std::getenv("CYPHAL__RUN"))
         {

--- a/docs/examples/1_presentation/example_1_presentation_3_hb_getinfo_ping_linux_can.cpp
+++ b/docs/examples/1_presentation/example_1_presentation_3_hb_getinfo_ping_linux_can.cpp
@@ -160,6 +160,8 @@ protected:
 
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         // Duration in seconds for which the test will run. Default is 10 seconds.
         if (const auto* const run_duration_str = std::getenv("CYPHAL__RUN"))
         {

--- a/docs/examples/2_application/example_2_application_0_node_hb_getinfo_udp.cpp
+++ b/docs/examples/2_application/example_2_application_0_node_hb_getinfo_udp.cpp
@@ -65,6 +65,8 @@ protected:
 
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         // Duration in seconds for which the test will run. Default is 10 seconds.
         if (const auto* const run_duration_str = std::getenv("CYPHAL__RUN"))
         {

--- a/test/unittest/application/node/test_get_info_provider.cpp
+++ b/test/unittest/application/node/test_get_info_provider.cpp
@@ -60,7 +60,7 @@ protected:
 
     void SetUp() override
     {
-        cetl::pmr::set_default_resource(&mr_default_);
+        cetl::pmr::set_default_resource(&mr_);
 
         EXPECT_CALL(transport_mock_, getProtocolParams())
             .WillRepeatedly(Return(ProtocolParams{std::numeric_limits<TransferId>::max(), 0, 0}));
@@ -70,10 +70,6 @@ protected:
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
-
-        EXPECT_THAT(mr_default_.allocations, IsEmpty());
-        EXPECT_THAT(mr_default_.total_allocated_bytes, mr_default_.total_deallocated_bytes);
-        EXPECT_THAT(mr_default_.total_allocated_bytes, 0);
     }
 
     TimePoint now() const
@@ -86,7 +82,6 @@ protected:
     // NOLINTBEGIN
     libcyphal::VirtualTimeScheduler scheduler_{};
     TrackingMemoryResource          mr_;
-    TrackingMemoryResource          mr_default_;
     StrictMock<TransportMock>       transport_mock_;
     // NOLINTEND
 };

--- a/test/unittest/application/node/test_heartbeat_producer.cpp
+++ b/test/unittest/application/node/test_heartbeat_producer.cpp
@@ -63,7 +63,7 @@ protected:
 
     void SetUp() override
     {
-        cetl::pmr::set_default_resource(&mr_default_);
+        cetl::pmr::set_default_resource(&mr_);
 
         EXPECT_CALL(transport_mock_, getProtocolParams())
             .WillRepeatedly(Return(ProtocolParams{std::numeric_limits<TransferId>::max(), 0, 0}));
@@ -73,10 +73,6 @@ protected:
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
-
-        EXPECT_THAT(mr_default_.allocations, IsEmpty());
-        EXPECT_THAT(mr_default_.total_allocated_bytes, mr_default_.total_deallocated_bytes);
-        EXPECT_THAT(mr_default_.total_allocated_bytes, 0);
     }
 
     TimePoint now() const
@@ -89,7 +85,6 @@ protected:
     // NOLINTBEGIN
     libcyphal::VirtualTimeScheduler scheduler_{};
     TrackingMemoryResource          mr_;
-    TrackingMemoryResource          mr_default_;
     StrictMock<TransportMock>       transport_mock_;
     // NOLINTEND
 };

--- a/test/unittest/application/node/test_registry_provider.cpp
+++ b/test/unittest/application/node/test_registry_provider.cpp
@@ -72,7 +72,7 @@ protected:
 
     void SetUp() override
     {
-        cetl::pmr::set_default_resource(&mr_default_);
+        cetl::pmr::set_default_resource(&mr_);
 
         EXPECT_CALL(transport_mock_, getProtocolParams())
             .WillRepeatedly(Return(ProtocolParams{std::numeric_limits<TransferId>::max(), 0, 0}));
@@ -82,10 +82,6 @@ protected:
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
-
-        EXPECT_THAT(mr_default_.allocations, IsEmpty());
-        EXPECT_THAT(mr_default_.total_allocated_bytes, mr_default_.total_deallocated_bytes);
-        EXPECT_THAT(mr_default_.total_allocated_bytes, 0);
     }
 
     TimePoint now() const
@@ -139,7 +135,6 @@ protected:
     // NOLINTBEGIN
     libcyphal::VirtualTimeScheduler        scheduler_{};
     TrackingMemoryResource                 mr_;
-    TrackingMemoryResource                 mr_default_;
     cetl::pmr::polymorphic_allocator<void> mr_alloc_{&mr_};
     StrictMock<TransportMock>              transport_mock_;
     // NOLINTEND

--- a/test/unittest/application/registry/test_register.cpp
+++ b/test/unittest/application/registry/test_register.cpp
@@ -54,18 +54,13 @@ protected:
 
     void SetUp() override
     {
-        cetl::pmr::set_default_resource(&mr_default_);
+        cetl::pmr::set_default_resource(&mr_);
     }
 
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
-
-        EXPECT_THAT(mr_default_.allocations, IsEmpty());
-        EXPECT_THAT(mr_default_.total_allocated_bytes, mr_default_.total_deallocated_bytes);
-        // TODO: Uncomment this when std::vector's allocator propagation issue will be resolved.
-        // EXPECT_THAT(mr_default_.total_allocated_bytes, 0);
     }
 
     IRegister::Value makeBitValue(const std::initializer_list<bool>& il) const
@@ -88,7 +83,6 @@ protected:
 
     // NOLINTBEGIN
     TrackingMemoryResource           mr_;
-    TrackingMemoryResource           mr_default_;
     IRegister::Value::allocator_type alloc_{&mr_};
     // NOLINTEND
 

--- a/test/unittest/application/registry/test_registry.cpp
+++ b/test/unittest/application/registry/test_registry.cpp
@@ -45,18 +45,13 @@ protected:
 
     void SetUp() override
     {
-        cetl::pmr::set_default_resource(&mr_default_);
+        cetl::pmr::set_default_resource(&mr_);
     }
 
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
-
-        EXPECT_THAT(mr_default_.allocations, IsEmpty());
-        EXPECT_THAT(mr_default_.total_allocated_bytes, mr_default_.total_deallocated_bytes);
-        // TODO: Uncomment this when std::vector's allocator propagation issue will be resolved.
-        // EXPECT_THAT(mr_default_.total_allocated_bytes, 0);
     }
 
     IRegister::Value makeEmptyValue() const
@@ -108,7 +103,6 @@ protected:
 
     // NOLINTBEGIN
     TrackingMemoryResource           mr_;
-    TrackingMemoryResource           mr_default_;
     IRegister::Value::allocator_type alloc_{&mr_};
     // NOLINTEND
 

--- a/test/unittest/application/test_node.cpp
+++ b/test/unittest/application/test_node.cpp
@@ -72,7 +72,7 @@ protected:
 
     void SetUp() override
     {
-        cetl::pmr::set_default_resource(&mr_default_);
+        cetl::pmr::set_default_resource(&mr_);
 
         EXPECT_CALL(transport_mock_, getProtocolParams())
             .WillRepeatedly(Return(ProtocolParams{std::numeric_limits<TransferId>::max(), 0, 0}));
@@ -82,10 +82,6 @@ protected:
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
-
-        EXPECT_THAT(mr_default_.allocations, IsEmpty());
-        EXPECT_THAT(mr_default_.total_allocated_bytes, mr_default_.total_deallocated_bytes);
-        EXPECT_THAT(mr_default_.total_allocated_bytes, 0);
     }
 
     void setupDefaultExpectations()
@@ -139,7 +135,6 @@ protected:
     // NOLINTBEGIN
     libcyphal::VirtualTimeScheduler  scheduler_{};
     TrackingMemoryResource           mr_;
-    TrackingMemoryResource           mr_default_;
     StrictMock<TransportMock>        transport_mock_;
     SvcServerContext                 getinfo_svc_cnxt_;
     StrictMock<MessageTxSessionMock> heartbeat_msg_tx_session_mock_;

--- a/test/unittest/presentation/test_client.cpp
+++ b/test/unittest/presentation/test_client.cpp
@@ -78,6 +78,8 @@ protected:
 
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         EXPECT_CALL(transport_mock_, getProtocolParams())
             .WillRepeatedly(Return(ProtocolParams{std::numeric_limits<TransferId>::max(), 0, 0}));
     }

--- a/test/unittest/presentation/test_presentation.cpp
+++ b/test/unittest/presentation/test_presentation.cpp
@@ -179,6 +179,8 @@ protected:
 
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         EXPECT_CALL(transport_mock_, getProtocolParams())
             .WillRepeatedly(Return(ProtocolParams{std::numeric_limits<TransferId>::max(), 0, 0}));
     }

--- a/test/unittest/presentation/test_publisher.cpp
+++ b/test/unittest/presentation/test_publisher.cpp
@@ -65,6 +65,11 @@ class TestPublisher : public testing::Test
 protected:
     using UniquePtrMsgTxSpec = MessageTxSessionMock::RefWrapper::Spec;
 
+    void SetUp() override
+    {
+        cetl::pmr::set_default_resource(&mr_);
+    }
+
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());

--- a/test/unittest/presentation/test_server.cpp
+++ b/test/unittest/presentation/test_server.cpp
@@ -66,6 +66,11 @@ protected:
     using UniquePtrReqRxSpec = RequestRxSessionMock::RefWrapper::Spec;
     using UniquePtrResTxSpec = ResponseTxSessionMock::RefWrapper::Spec;
 
+    void SetUp() override
+    {
+        cetl::pmr::set_default_resource(&mr_);
+    }
+
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());

--- a/test/unittest/presentation/test_subscriber.cpp
+++ b/test/unittest/presentation/test_subscriber.cpp
@@ -71,6 +71,11 @@ class TestSubscriber : public testing::Test
 protected:
     using UniquePtrMsgRxSpec = MessageRxSessionMock::RefWrapper::Spec;
 
+    void SetUp() override
+    {
+        cetl::pmr::set_default_resource(&mr_);
+    }
+
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());

--- a/test/unittest/test_types.cpp
+++ b/test/unittest/test_types.cpp
@@ -63,6 +63,11 @@ protected:
         std::string name_;
     };
 
+    void SetUp() override
+    {
+        cetl::pmr::set_default_resource(&mr_);
+    }
+
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());

--- a/test/unittest/transport/can/test_can_delegate.cpp
+++ b/test/unittest/transport/can/test_can_delegate.cpp
@@ -71,6 +71,11 @@ protected:
         MOCK_METHOD(void, onSessionEvent, (const SessionEvent::Variant& event_var), (override));
     };
 
+    void SetUp() override
+    {
+        cetl::pmr::set_default_resource(&mr_);
+    }
+
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());

--- a/test/unittest/transport/can/test_can_msg_rx_session.cpp
+++ b/test/unittest/transport/can/test_can_msg_rx_session.cpp
@@ -68,6 +68,8 @@ class TestCanMsgRxSession : public testing::Test
 protected:
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         EXPECT_CALL(media_mock_, getMtu())  //
             .WillRepeatedly(Return(CANARD_MTU_MAX));
     }

--- a/test/unittest/transport/can/test_can_msg_tx_session.cpp
+++ b/test/unittest/transport/can/test_can_msg_tx_session.cpp
@@ -69,6 +69,8 @@ class TestCanMsgTxSession : public testing::Test
 protected:
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         EXPECT_CALL(media_mock_, getMtu())  //
             .WillRepeatedly(Return(CANARD_MTU_CAN_CLASSIC));
         EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //

--- a/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
@@ -78,6 +78,8 @@ class TestCanSvcRxSessions : public testing::Test
 protected:
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         EXPECT_CALL(media_mock_, getMtu())  //
             .WillRepeatedly(Return(CANARD_MTU_CAN_CLASSIC));
     }

--- a/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
@@ -64,6 +64,8 @@ class TestCanSvcTxSessions : public testing::Test
 protected:
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         EXPECT_CALL(media_mock_, getMtu())  //
             .WillRepeatedly(Return(CANARD_MTU_CAN_CLASSIC));
         EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //

--- a/test/unittest/transport/can/test_can_transport.cpp
+++ b/test/unittest/transport/can/test_can_transport.cpp
@@ -104,6 +104,8 @@ class TestCanTransport : public testing::Test
 protected:
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         EXPECT_CALL(media_mock_, getMtu()).WillRepeatedly(Return(CANARD_MTU_CAN_CLASSIC));
     }
 

--- a/test/unittest/transport/test_contiguous_payload.cpp
+++ b/test/unittest/transport/test_contiguous_payload.cpp
@@ -36,6 +36,11 @@ using testing::ElementsAre;
 class TestContiguousPayload : public testing::Test
 {
 protected:
+    void SetUp() override
+    {
+        cetl::pmr::set_default_resource(&mr_);
+    }
+
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());

--- a/test/unittest/transport/udp/test_session_tree.cpp
+++ b/test/unittest/transport/udp/test_session_tree.cpp
@@ -63,6 +63,11 @@ protected:
         std::function<void(const std::string&)> notifier_;
     };
 
+    void SetUp() override
+    {
+        cetl::pmr::set_default_resource(&mr_);
+    }
+
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());

--- a/test/unittest/transport/udp/test_udp_delegate.cpp
+++ b/test/unittest/transport/udp/test_udp_delegate.cpp
@@ -83,6 +83,11 @@ protected:
 
     };  // TransportDelegateImpl
 
+    void SetUp() override
+    {
+        cetl::pmr::set_default_resource(&general_mr_);
+    }
+
     void TearDown() override
     {
         EXPECT_THAT(general_mr_.allocations, IsEmpty());

--- a/test/unittest/transport/udp/test_udp_msg_rx_session.cpp
+++ b/test/unittest/transport/udp/test_udp_msg_rx_session.cpp
@@ -73,6 +73,8 @@ class TestUdpMsgRxSession : public testing::Test
 protected:
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         EXPECT_CALL(media_mock_, makeTxSocket())  //
             .WillRepeatedly(Invoke([this] {
                 return libcyphal::detail::makeUniquePtr<TxSocketMock::RefWrapper::Spec>(mr_, tx_socket_mock_);

--- a/test/unittest/transport/udp/test_udp_msg_tx_session.cpp
+++ b/test/unittest/transport/udp/test_udp_msg_tx_session.cpp
@@ -74,6 +74,8 @@ class TestUdpMsgTxSession : public testing::Test
 protected:
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         EXPECT_CALL(media_mock_, makeTxSocket())  //
             .WillRepeatedly(Invoke([this] {
                 return libcyphal::detail::makeUniquePtr<TxSocketMock::RefWrapper::Spec>(mr_, tx_socket_mock_);

--- a/test/unittest/transport/udp/test_udp_svc_rx_sessions.cpp
+++ b/test/unittest/transport/udp/test_udp_svc_rx_sessions.cpp
@@ -76,6 +76,8 @@ class TestUdpSvcRxSessions : public testing::Test
 protected:
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         EXPECT_CALL(media_mock_, makeTxSocket())  //
             .WillRepeatedly(Invoke([this] {
                 return libcyphal::detail::makeUniquePtr<TxSocketMock::RefWrapper::Spec>(mr_, tx_socket_mock_);

--- a/test/unittest/transport/udp/test_udp_svc_tx_sessions.cpp
+++ b/test/unittest/transport/udp/test_udp_svc_tx_sessions.cpp
@@ -67,6 +67,8 @@ class TestUdpSvcTxSessions : public testing::Test
 protected:
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         EXPECT_CALL(media_mock_, makeTxSocket())  //
             .WillRepeatedly(Invoke([this] {
                 return libcyphal::detail::makeUniquePtr<TxSocketMock::RefWrapper::Spec>(mr_, tx_socket_mock_);

--- a/test/unittest/transport/udp/test_udp_transport.cpp
+++ b/test/unittest/transport/udp/test_udp_transport.cpp
@@ -101,6 +101,8 @@ class TestUpdTransport : public testing::Test
 protected:
     void SetUp() override
     {
+        cetl::pmr::set_default_resource(&mr_);
+
         EXPECT_CALL(media_mock_, makeTxSocket())  //
             .WillRepeatedly(Invoke([this] {
                 return libcyphal::detail::makeUniquePtr<TxSocketMock::RefWrapper::Spec>(mr_, tx_socket_mock_);


### PR DESCRIPTION
Set default PMR, so that default behavior of `std::pmr::polymorphic_allocator` stays with specific memory resource (instead of default "new/delete" one) #verification #docs #sonar