### PR TITLE
Single copy TX pipeline

### DIFF
--- a/cmake/modules/Findlibcanard.cmake
+++ b/cmake/modules/Findlibcanard.cmake
@@ -9,7 +9,7 @@
 include(FetchContent)
 
 set(libcanard_GIT_REPOSITORY "https://github.com/OpenCyphal/libcanard.git")
-set(libcanard_GIT_TAG "v4")
+set(libcanard_GIT_TAG "sshirokov/v4_zero_tx_copy")
 
 FetchContent_Declare(
     libcanard

--- a/cmake/modules/Findlibcanard.cmake
+++ b/cmake/modules/Findlibcanard.cmake
@@ -9,7 +9,7 @@
 include(FetchContent)
 
 set(libcanard_GIT_REPOSITORY "https://github.com/OpenCyphal/libcanard.git")
-set(libcanard_GIT_TAG "sshirokov/v4_zero_tx_copy")
+set(libcanard_GIT_TAG "v4")
 
 FetchContent_Declare(
     libcanard

--- a/docs/examples/platform/linux/can/socketcan.c
+++ b/docs/examples/platform/linux/can/socketcan.c
@@ -7,6 +7,7 @@
 #    define _GNU_SOURCE
 #endif
 
+#include "canard.h"
 #include "socketcan.h"
 
 #ifdef __linux__

--- a/include/libcyphal/transport/can/can_transport_impl.hpp
+++ b/include/libcyphal/transport/can/can_transport_impl.hpp
@@ -112,7 +112,12 @@ class TransportImpl final : private TransportDelegate, public ICanTransport  // 
         {
             using LizardHelpers = libcyphal::transport::detail::LizardHelpers;
 
-            return LizardHelpers::makeMemoryResource<CanardMemoryResource>(media_interface.getTxMemoryResource());
+            // TX memory resource is used for raw bytes block allocations only.
+            // So it has no alignment requirements.
+            constexpr std::size_t Alignment = 1;
+
+            return LizardHelpers::makeMemoryResource<CanardMemoryResource, Alignment>(
+                media_interface.getTxMemoryResource());
         }
 
         const std::uint8_t       index_;

--- a/include/libcyphal/transport/can/can_transport_impl.hpp
+++ b/include/libcyphal/transport/can/can_transport_impl.hpp
@@ -574,18 +574,20 @@ private:
     ///
     void pushNextFrameToMedia(Media& media)
     {
-        using PayloadFragment = cetl::span<const cetl::byte>;
-
         TimePoint tx_deadline;
-        while (const CanardTxQueueItem* const tx_item = peekFirstValidTxItem(media.canard_tx_queue(), tx_deadline))
+        while (CanardTxQueueItem* const tx_item = peekFirstValidTxItem(media.canard_tx_queue(), tx_deadline))
         {
+            // Move the payload from the frame to the media payload - `media.push` might take ownership of it.
             // No Sonar `cpp:S5356` and `cpp:S5357` b/c we integrate here with C libcanard API.
-            const auto* const buffer =
-                static_cast<const cetl::byte*>(tx_item->frame.payload.data);  // NOSONAR cpp:S5356 cpp:S5357
-            const PayloadFragment payload{buffer, tx_item->frame.payload.size};
+            //
+            auto&        frame_payload = tx_item->frame.payload;
+            MediaPayload payload{frame_payload.size,
+                                 static_cast<cetl::byte*>(frame_payload.data),  // NOSONAR cpp:S5356 cpp:S5357
+                                 frame_payload.allocated_size,
+                                 &media.interface().getTxMemoryResource()};
+            frame_payload = {0, nullptr, 0};
 
-            IMedia::PushResult::Type push_result =
-                media.interface().push(tx_deadline, tx_item->frame.extended_can_id, payload);
+            auto push_result = media.interface().push(tx_deadline, tx_item->frame.extended_can_id, payload);
 
             // In case of media push error, we are going to drop this problematic frame
             // (b/c it looks like media can't handle this frame),
@@ -603,6 +605,15 @@ private:
                                                 canard_instance(),
                                                 tx_item,
                                                 false /* single frame */);
+                }
+                else
+                {
+                    // Media has not accepted the frame, so we need return original payload back to the item,
+                    // so that in the future potential retry could try to push it again.
+                    const auto org_payload       = payload.release();
+                    frame_payload.size           = std::get<0>(org_payload);
+                    frame_payload.data           = std::get<1>(org_payload);
+                    frame_payload.allocated_size = std::get<2>(org_payload);
                 }
 
                 // If needed schedule (recursively!) next frame to push.
@@ -637,12 +648,11 @@ private:
     /// While searching, any of already expired TX items are pop from the queue and freed (aka dropped).
     /// If there is no still valid TX items in the queue, returns `nullptr`.
     ///
-    CETL_NODISCARD const CanardTxQueueItem* peekFirstValidTxItem(CanardTxQueue& canard_tx,
-                                                                 TimePoint&     out_deadline) const
+    CETL_NODISCARD CanardTxQueueItem* peekFirstValidTxItem(CanardTxQueue& canard_tx, TimePoint& out_deadline) const
     {
         const TimePoint now = executor_.now();
 
-        while (const CanardTxQueueItem* const tx_item = ::canardTxPeek(&canard_tx))
+        while (CanardTxQueueItem* const tx_item = ::canardTxPeek(&canard_tx))
         {
             // We are dropping any TX item that has expired.
             // Otherwise, we would push it to the media interface.

--- a/include/libcyphal/transport/can/media.hpp
+++ b/include/libcyphal/transport/can/media.hpp
@@ -8,6 +8,7 @@
 
 #include "libcyphal/executor.hpp"
 #include "libcyphal/transport/errors.hpp"
+#include "libcyphal/transport/media_payload.hpp"
 #include "libcyphal/types.hpp"
 
 #include <cetl/cetl.hpp>
@@ -66,9 +67,16 @@ public:
 
     /// @brief Schedules the frame for transmission asynchronously and return immediately.
     ///
+    /// Concrete media implementation has multiple options with how to handle `payload` buffer:
+    /// - just copy the buffer data byts (using `payload.getSpan` const method) and return without changing the payload;
+    /// - take ownership of the buffer (by moving the payload to another internal payload;
+    /// - calling `payload.reset()` immediately after it's not needed anymore.
+    /// In any case, the payload should not be changed (moved or reset) if it is not accepted.
+    ///
     /// @param deadline The deadline for the push operation. Media implementation should drop the payload
     ///                 if the deadline is exceeded (aka `now > deadline`).
     /// @param can_id The destination CAN ID of the frame.
+    /// @param payload The mutable payload of the frame. Should not be changed if payload is not accepted.
     /// @return `true` if the frame is accepted or already timed out;
     ///         `false` to try again later (f.e. b/c output TX queue is currently full).
     ///         If any media failure occurred, the frame will be dropped by transport.
@@ -83,9 +91,7 @@ public:
 
         using Type = Expected<Success, Failure>;
     };
-    virtual PushResult::Type push(const TimePoint                    deadline,
-                                  const CanId                        can_id,
-                                  const cetl::span<const cetl::byte> payload) noexcept = 0;
+    virtual PushResult::Type push(const TimePoint deadline, const CanId can_id, MediaPayload& payload) noexcept = 0;
     ///@}
 
     /// @brief Takes the next payload fragment (aka CAN frame) from the reception queue unless it's empty.

--- a/include/libcyphal/transport/lizard_helpers.hpp
+++ b/include/libcyphal/transport/lizard_helpers.hpp
@@ -27,17 +27,18 @@ public:
 
     /// Constructs a lizard C memory resource.
     ///
-    template <typename MemoryResource>
+    template <typename MemoryResource, std::size_t Alignment = alignof(std::max_align_t)>
     CETL_NODISCARD static MemoryResource makeMemoryResource(cetl::pmr::memory_resource& memory)
     {
         /// No Sonar `cpp:S5356` is unavoidable - integration with Lizard C memory management.
         ///
-        return {&memory, deallocateMemory, allocateMemory};  // NOSONAR cpp:S5356
+        return {&memory, deallocateMemory<Alignment>, allocateMemory<Alignment>};  // NOSONAR cpp:S5356
     }
 
 private:
     /// No Sonar `cpp:S5008` is unavoidable - integration with Lizard C memory management.
     ///
+    template <std::size_t Alignment>
     static void* allocateMemory(void* const user_reference, const std::size_t amount)  // NOSONAR cpp:S5008
     {
         // No Sonar `cpp:S5357` "... isn't related to `void*`.
@@ -45,11 +46,12 @@ private:
         auto* const memory = static_cast<cetl::pmr::memory_resource*>(user_reference);  // NOSONAR cpp:S5357
         CETL_DEBUG_ASSERT(nullptr != user_reference, "Expected PMR as non-null user reference.");
 
-        return memory->allocate(amount);
+        return memory->allocate(amount, Alignment);
     }
 
     /// No Sonar `cpp:S5008` is unavoidable - integration with Lizard C memory management.
     ///
+    template <std::size_t Alignment>
     static void deallocateMemory(void* const       user_reference,  // NOSONAR cpp:S5008
                                  const std::size_t amount,
                                  void* const       pointer)  // NOSONAR cpp:S5008
@@ -59,7 +61,7 @@ private:
         auto* const memory = static_cast<cetl::pmr::memory_resource*>(user_reference);  // NOSONAR cpp:S5357
         CETL_DEBUG_ASSERT(nullptr != user_reference, "Expected PMR as non-null user reference.");
 
-        memory->deallocate(pointer, amount);
+        memory->deallocate(pointer, amount, Alignment);
     }
 
 };  // LizardHelpers

--- a/include/libcyphal/transport/media_payload.hpp
+++ b/include/libcyphal/transport/media_payload.hpp
@@ -1,0 +1,162 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef LIBCYPHAL_TRANSPORT_MEDIA_PAYLOAD_HPP_INCLUDED
+#define LIBCYPHAL_TRANSPORT_MEDIA_PAYLOAD_HPP_INCLUDED
+
+#include <cetl/pf17/cetlpf.hpp>
+#include <cetl/pf20/cetlpf.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+namespace libcyphal
+{
+namespace transport
+{
+
+/// Defines a mutable media payload.
+///
+/// In use to pass payload data between the transport layer and its media.
+/// It also manages memory ownership of the allocated payload buffer.
+///
+class MediaPayload final  // NOSONAR : cpp:S4963 - we do directly handle resources here.
+{
+public:
+    /// Constructs a new empty payload.
+    ///
+    MediaPayload() = default;
+
+    /// Constructs a new payload by owning the provided data buffer.
+    ///
+    /// @param size The size of the payload data in bytes. Must be less or equal to the allocated size.
+    /// @param data The pointer to the payload data buffer.
+    /// @param allocated_size The size of the allocated buffer. Must be greater or equal to the payload size.
+    /// @param mr The PMR which was used to allocate the payload buffer. Will be used to deallocate it.
+    ///
+    MediaPayload(const std::size_t                 size,
+                 cetl::byte* const                 data,
+                 const std::size_t                 allocated_size,
+                 cetl::pmr::memory_resource* const mr)
+        : size_{size}
+        , data_{data}
+        , allocated_size_{allocated_size}
+        , mr_{mr}
+    {
+    }
+
+    /// Moves another payload into this new payload instance.
+    ///
+    /// @param other The other payload to move into.
+    ///
+    MediaPayload(MediaPayload&& other) noexcept
+        : size_{std::exchange(other.size_, 0U)}
+        , data_{std::exchange(other.data_, nullptr)}
+        , allocated_size_{std::exchange(other.allocated_size_, 0U)}
+        , mr_{std::exchange(other.mr_, nullptr)}
+    {
+    }
+
+    /// @brief Assigns another payload by moving it into this one.
+    ///
+    /// @param other The other payload to move into.
+    ///
+    MediaPayload& operator=(MediaPayload&& other) noexcept
+    {
+        reset();
+
+        size_           = std::exchange(other.size_, 0U);
+        data_           = std::exchange(other.data_, nullptr);
+        allocated_size_ = std::exchange(other.allocated_size_, 0U);
+        mr_             = std::exchange(other.mr_, nullptr);
+
+        return *this;
+    }
+
+    // No copying, but move only!
+    MediaPayload(const MediaPayload& other)            = delete;
+    MediaPayload& operator=(const MediaPayload& other) = delete;
+
+    ~MediaPayload()
+    {
+        reset();
+    }
+
+    /// Gets the constant payload data as a span.
+    ///
+    /// Returns an empty (`{nullptr, 0}`) span if the payload is moved, released or reset.
+    ///
+    cetl::span<const cetl::byte> getSpan() const noexcept
+    {
+        return {data_, size_};
+    }
+
+    /// Releases ownership of the payload by returning its data pointer and sizes.
+    ///
+    /// In use to return the payload to the lizard C API when media is not ready yet to accept the payload.
+    /// After this call, corresponding internal fields will be nullified.
+    ///
+    /// @return Tuple with the payload size, pointer to the payload data, and the allocated size.
+    ///         It's the caller's responsibility to deallocate the buffer with the correct memory resource,
+    ///         or move it somewhere else with the same guarantee (like f.e. back to a lizard TX queue item).
+    ///
+    std::tuple<std::size_t, void*, std::size_t> release() noexcept
+    {
+        mr_ = nullptr;
+        return std::make_tuple(std::exchange(size_, 0U),
+                               std::exchange(data_, nullptr),
+                               std::exchange(allocated_size_, 0U));
+    }
+
+    /// Resets the payload by de-allocating its data buffer.
+    ///
+    /// Could be called multiple times.
+    ///
+    void reset() noexcept
+    {
+        if ((data_ != nullptr) && (mr_ != nullptr))
+        {
+            size_ = 0;
+
+            mr_->deallocate(data_, allocated_size_);
+
+            mr_             = nullptr;
+            data_           = nullptr;
+            allocated_size_ = 0;
+        }
+    }
+
+private:
+    /// Size of the payload data in bytes.
+    ///
+    /// Could be less or equal to the allocated size.
+    /// `0` when the payload is moved.
+    ///
+    std::size_t size_{0U};
+
+    /// Pointer to the payload buffer.
+    ///
+    /// `nullptr` when the payload is moved.
+    ///
+    cetl::byte* data_{nullptr};
+
+    /// Size of the allocated buffer.
+    ///
+    /// Could be greater or equal to the payload size.
+    /// `0` when the payload is moved.
+    ///
+    std::size_t allocated_size_{0U};
+
+    /// Holds pointer to the PMR which was used to allocate the payload buffer. Will be used to deallocate it.
+    ///
+    cetl::pmr::memory_resource* mr_{nullptr};
+
+};  // MediaPayload
+
+}  // namespace transport
+}  // namespace libcyphal
+
+#endif  // LIBCYPHAL_TRANSPORT_MEDIA_PAYLOAD_HPP_INCLUDED

--- a/include/libcyphal/transport/udp/udp_transport_impl.hpp
+++ b/include/libcyphal/transport/udp/udp_transport_impl.hpp
@@ -122,7 +122,12 @@ class TransportImpl final : private TransportDelegate, public IUdpTransport  // 
         {
             using LizardHelpers = libcyphal::transport::detail::LizardHelpers;
 
-            return LizardHelpers::makeMemoryResource<UdpardMemoryResource>(media_interface.getTxMemoryResource());
+            // TODO: Make it `1` as soon as TX memory resource is used for raw bytes block allocations only.
+            // Currently, it is used for both `UdpardTxItem` and its payload.
+            constexpr std::size_t Alignment = alignof(UdpardTxItem);
+
+            return LizardHelpers::makeMemoryResource<UdpardMemoryResource, Alignment>(
+                media_interface.getTxMemoryResource());
         }
 
         const std::uint8_t     index_;

--- a/test/unittest/sonar.cpp
+++ b/test/unittest/sonar.cpp
@@ -41,6 +41,7 @@
 #include <libcyphal/transport/contiguous_payload.hpp>
 #include <libcyphal/transport/errors.hpp>
 #include <libcyphal/transport/lizard_helpers.hpp>
+#include <libcyphal/transport/media_payload.hpp>
 #include <libcyphal/transport/msg_sessions.hpp>
 #include <libcyphal/transport/scattered_buffer.hpp>
 #include <libcyphal/transport/session.hpp>

--- a/test/unittest/transport/can/media_mock.hpp
+++ b/test/unittest/transport/can/media_mock.hpp
@@ -42,7 +42,7 @@ public:
 
     MOCK_METHOD(PushResult::Type,
                 push,
-                (const TimePoint deadline, const CanId can_id, const cetl::span<const cetl::byte> payload),
+                (const TimePoint deadline, const CanId can_id, MediaPayload& payload),
                 (noexcept, override));
 
     MOCK_METHOD(PopResult::Type, pop, (const cetl::span<cetl::byte> payload_buffer), (noexcept, override));

--- a/test/unittest/transport/can/test_can_msg_tx_session.cpp
+++ b/test/unittest/transport/can/test_can_msg_tx_session.cpp
@@ -179,14 +179,14 @@ TEST_F(TestCanMsgTxSession, send_empty_payload)
         // Emulate that media has not accepted the payload.
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto payload) {
+            .WillOnce([&](auto deadline, auto can_id, auto& payload) {
                 EXPECT_THAT(now(), metadata.deadline - timeout);
                 EXPECT_THAT(deadline, metadata.deadline);
                 EXPECT_THAT(can_id, SubjectOfCanIdEq(123));
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
                 auto tbm = TailByteEq(metadata.base.transfer_id);
-                EXPECT_THAT(payload, ElementsAre(tbm));
+                EXPECT_THAT(payload.getSpan(), ElementsAre(tbm));
                 return IMedia::PushResult::Success{false /* is_accepted */};
             });
         EXPECT_CALL(media_mock_, registerPushCallback(_))  //
@@ -263,13 +263,13 @@ TEST_F(TestCanMsgTxSession, send_7bytes_payload_with_500ms_timeout)
     scheduler_.scheduleAt(1s + timeout - 1us, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto, auto can_id, auto pld) {
+            .WillOnce([&](auto, auto can_id, auto& pld) {
                 EXPECT_THAT(now(), metadata.deadline - 1us);
                 EXPECT_THAT(can_id, SubjectOfCanIdEq(17));
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
                 auto tbm = TailByteEq(metadata.base.transfer_id);
-                EXPECT_THAT(pld, ElementsAre(b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), b('7'), tbm));
+                EXPECT_THAT(pld.getSpan(), ElementsAre(b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), b('7'), tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
     });

--- a/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
@@ -183,7 +183,7 @@ TEST_F(TestCanSvcTxSessions, send_request)
     scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto payload) {
+            .WillOnce([&](auto deadline, auto can_id, auto& payload) {
                 EXPECT_THAT(now(), metadata.deadline - timeout);
                 EXPECT_THAT(deadline, metadata.deadline);
                 EXPECT_THAT(can_id, ServiceOfCanIdEq(123));
@@ -191,7 +191,7 @@ TEST_F(TestCanSvcTxSessions, send_request)
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsServiceCanId()));
 
                 auto tbm = TailByteEq(metadata.base.transfer_id);
-                EXPECT_THAT(payload, ElementsAre(tbm));
+                EXPECT_THAT(payload.getSpan(), ElementsAre(tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
         EXPECT_CALL(media_mock_, registerPushCallback(_))  //
@@ -235,7 +235,7 @@ TEST_F(TestCanSvcTxSessions, send_request_with_argument_error)
         EXPECT_THAT(transport->setLocalNodeId(13), Eq(cetl::nullopt));
 
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto payload) {
+            .WillOnce([&](auto deadline, auto can_id, auto& payload) {
                 EXPECT_THAT(now(), metadata.deadline - timeout);
                 EXPECT_THAT(deadline, metadata.deadline);
                 EXPECT_THAT(can_id, ServiceOfCanIdEq(123));
@@ -243,7 +243,7 @@ TEST_F(TestCanSvcTxSessions, send_request_with_argument_error)
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsServiceCanId()));
 
                 auto tbm = TailByteEq(metadata.base.transfer_id);
-                EXPECT_THAT(payload, ElementsAre(tbm));
+                EXPECT_THAT(payload.getSpan(), ElementsAre(tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
         EXPECT_CALL(media_mock_, registerPushCallback(_))  //
@@ -319,7 +319,7 @@ TEST_F(TestCanSvcTxSessions, send_response)
     scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto payload) {
+            .WillOnce([&](auto deadline, auto can_id, auto& payload) {
                 EXPECT_THAT(now(), metadata.tx_meta.deadline - timeout);
                 EXPECT_THAT(deadline, metadata.tx_meta.deadline);
                 EXPECT_THAT(can_id, ServiceOfCanIdEq(123));
@@ -327,7 +327,7 @@ TEST_F(TestCanSvcTxSessions, send_response)
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.tx_meta.base.priority), IsServiceCanId()));
 
                 auto tbm = TailByteEq(metadata.tx_meta.base.transfer_id);
-                EXPECT_THAT(payload, ElementsAre(tbm));
+                EXPECT_THAT(payload.getSpan(), ElementsAre(tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
         EXPECT_CALL(media_mock_, registerPushCallback(_))  //

--- a/test/unittest/transport/can/test_can_transport.cpp
+++ b/test/unittest/transport/can/test_can_transport.cpp
@@ -533,14 +533,14 @@ TEST_F(TestCanTransport, sending_multiframe_payload_for_non_anonymous)
 
     scheduler_.scheduleAt(1s, [&](const auto&) {
         //
-        EXPECT_CALL(media_mock_, push(_, _, _)).WillOnce([&](auto deadline, auto can_id, auto pld) {
+        EXPECT_CALL(media_mock_, push(_, _, _)).WillOnce([&](auto deadline, auto can_id, auto& pld) {
             EXPECT_THAT(now(), metadata.deadline - timeout);
             EXPECT_THAT(deadline, metadata.deadline);
             EXPECT_THAT(can_id, AllOf(SubjectOfCanIdEq(7), SourceNodeOfCanIdEq(0x45)));
             EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
             const auto tbm = TailByteEq(metadata.base.transfer_id, true, false);
-            EXPECT_THAT(pld, ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
+            EXPECT_THAT(pld.getSpan(), ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
             return IMedia::PushResult::Success{true /* is_accepted */};
         });
         EXPECT_CALL(media_mock_, registerPushCallback(_))  //
@@ -554,14 +554,14 @@ TEST_F(TestCanTransport, sending_multiframe_payload_for_non_anonymous)
     });
     scheduler_.scheduleAt(1s + 10us, [&](const auto&) {
         //
-        EXPECT_CALL(media_mock_, push(_, _, _)).WillOnce([&](auto deadline, auto can_id, auto pld) {
+        EXPECT_CALL(media_mock_, push(_, _, _)).WillOnce([&](auto deadline, auto can_id, auto& pld) {
             EXPECT_THAT(now(), metadata.deadline - timeout + 10us);
             EXPECT_THAT(deadline, metadata.deadline);
             EXPECT_THAT(can_id, AllOf(SubjectOfCanIdEq(7), SourceNodeOfCanIdEq(0x45)));
             EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
             const auto tbm = TailByteEq(metadata.base.transfer_id, false, true, false);
-            EXPECT_THAT(pld, ElementsAre(b('7'), _, _ /* CRC bytes */, tbm));
+            EXPECT_THAT(pld.getSpan(), ElementsAre(b('7'), _, _ /* CRC bytes */, tbm));
             return IMedia::PushResult::Success{true /* is_accepted */};
         });
     });
@@ -598,7 +598,7 @@ TEST_F(TestCanTransport, send_multiframe_payload_to_redundant_not_ready_media)
         // the second media, and will retry with the 1st only when its socket is ready @ +20us.
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto, auto, auto) {
+            .WillOnce([&](auto, auto, auto&) {
                 EXPECT_THAT(now(), metadata.deadline - timeout);
                 return IMedia::PushResult::Success{false /* is_accepted */};
             });
@@ -607,14 +607,14 @@ TEST_F(TestCanTransport, send_multiframe_payload_to_redundant_not_ready_media)
                 return scheduler_.registerAndScheduleNamedCallback("tx1", now() + 20us, std::move(function));
             }));
         EXPECT_CALL(media_mock2, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto pld) {
+            .WillOnce([&](auto deadline, auto can_id, auto& pld) {
                 EXPECT_THAT(now(), metadata.deadline - timeout);
                 EXPECT_THAT(deadline, metadata.deadline);
                 EXPECT_THAT(can_id, AllOf(SubjectOfCanIdEq(7), SourceNodeOfCanIdEq(0x45)));
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
                 auto tbm = TailByteEq(metadata.base.transfer_id, true, false);
-                EXPECT_THAT(pld, ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
+                EXPECT_THAT(pld.getSpan(), ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
         EXPECT_CALL(media_mock2, registerPushCallback(_))  //
@@ -629,28 +629,28 @@ TEST_F(TestCanTransport, send_multiframe_payload_to_redundant_not_ready_media)
     scheduler_.scheduleAt(1s + 10us, [&](const auto&) {
         //
         EXPECT_CALL(media_mock2, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto pld) {
+            .WillOnce([&](auto deadline, auto can_id, auto& pld) {
                 EXPECT_THAT(now(), metadata.deadline - timeout + 10us);
                 EXPECT_THAT(deadline, metadata.deadline);
                 EXPECT_THAT(can_id, AllOf(SubjectOfCanIdEq(7), SourceNodeOfCanIdEq(0x45)));
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
                 const auto tbm = TailByteEq(metadata.base.transfer_id, false, true, false);
-                EXPECT_THAT(pld, ElementsAre(b('7'), b('8'), b('9'), b(0x7D), b(0x61) /* CRC bytes */, tbm));
+                EXPECT_THAT(pld.getSpan(), ElementsAre(b('7'), b('8'), b('9'), b(0x7D), b(0x61) /* CRC bytes */, tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
     });
     scheduler_.scheduleAt(1s + 20us, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto pld) {
+            .WillOnce([&](auto deadline, auto can_id, auto& pld) {
                 EXPECT_THAT(now(), metadata.deadline - timeout + 20us);
                 EXPECT_THAT(deadline, metadata.deadline);
                 EXPECT_THAT(can_id, AllOf(SubjectOfCanIdEq(7), SourceNodeOfCanIdEq(0x45)));
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
                 const auto tbm = TailByteEq(metadata.base.transfer_id, true, false);
-                EXPECT_THAT(pld, ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
+                EXPECT_THAT(pld.getSpan(), ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
     });

--- a/test/unittest/transport/test_media_payload.cpp
+++ b/test/unittest/transport/test_media_payload.cpp
@@ -1,0 +1,145 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#include "tracking_memory_resource.hpp"
+
+#include <cetl/pf17/cetlpf.hpp>
+#include <libcyphal/transport/media_payload.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <utility>
+
+namespace
+{
+
+using namespace libcyphal::transport;  // NOLINT This our main concern here in the unit tests.
+
+using testing::IsEmpty;
+
+class TestMediaPayload : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        cetl::pmr::set_default_resource(&mr_);
+    }
+
+    void TearDown() override
+    {
+        EXPECT_THAT(mr_.allocations, IsEmpty());
+        EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
+    }
+
+    // MARK: Data members:
+
+    // NOLINTBEGIN
+    TrackingMemoryResource mr_;
+    // NOLINTEND
+};
+
+// MARK: - Tests:
+
+TEST_F(TestMediaPayload, default_ctor)
+{
+    MediaPayload payload;
+    EXPECT_THAT(payload.getSpan().size(), 0);
+    EXPECT_THAT(payload.getSpan().data(), nullptr);
+    EXPECT_THAT(payload.getAllocatedSize(), 0);
+
+    // It's fine to attempt to reset or release an empty payload.
+    const auto fields = payload.release();
+    EXPECT_THAT(std::get<0>(fields), 0);
+    EXPECT_THAT(std::get<1>(fields), nullptr);
+    EXPECT_THAT(std::get<2>(fields), 0);
+
+    payload.reset();
+}
+
+TEST_F(TestMediaPayload, main_ctor)
+{
+    constexpr std::size_t payload_size           = 5;
+    constexpr std::size_t payload_allocated_size = 8;
+    auto* const           payload_data           = static_cast<cetl::byte*>(mr_.allocate(payload_allocated_size));
+
+    const MediaPayload payload{payload_size, payload_data, payload_allocated_size, &mr_};
+    EXPECT_THAT(payload.getSpan().size(), payload_size);
+    EXPECT_THAT(payload.getSpan().data(), payload_data);
+    EXPECT_THAT(payload.getAllocatedSize(), payload_allocated_size);
+}
+
+TEST_F(TestMediaPayload, move_ctor)
+{
+    constexpr std::size_t payload_size           = 5;
+    constexpr std::size_t payload_allocated_size = 8;
+    auto* const           payload_data           = static_cast<cetl::byte*>(mr_.allocate(payload_allocated_size));
+
+    MediaPayload payload1{payload_size, payload_data, payload_allocated_size, &mr_};
+
+    const MediaPayload payload2{std::move(payload1)};
+
+    EXPECT_THAT(payload2.getSpan().size(), payload_size);
+    EXPECT_THAT(payload2.getSpan().data(), payload_data);
+    EXPECT_THAT(payload2.getAllocatedSize(), payload_allocated_size);
+}
+
+TEST_F(TestMediaPayload, move_assignment)
+{
+    constexpr std::size_t payload_size           = 5;
+    constexpr std::size_t payload_allocated_size = 8;
+    auto* const           payload_data           = static_cast<cetl::byte*>(mr_.allocate(payload_allocated_size));
+
+    MediaPayload payload1{payload_size, payload_data, payload_allocated_size, &mr_};
+
+    MediaPayload payload2{};
+    payload2 = std::move(payload1);
+
+    EXPECT_THAT(payload2.getSpan().size(), payload_size);
+    EXPECT_THAT(payload2.getSpan().data(), payload_data);
+    EXPECT_THAT(payload2.getAllocatedSize(), payload_allocated_size);
+}
+
+TEST_F(TestMediaPayload, release)
+{
+    constexpr std::size_t payload_size           = 5;
+    constexpr std::size_t payload_allocated_size = 8;
+    auto* const           payload_data           = static_cast<cetl::byte*>(mr_.allocate(payload_allocated_size));
+
+    MediaPayload payload{payload_size, payload_data, payload_allocated_size, &mr_};
+
+    auto fields = payload.release();
+    EXPECT_THAT(std::get<0>(fields), payload_size);
+    EXPECT_THAT(std::get<1>(fields), payload_data);
+    EXPECT_THAT(std::get<2>(fields), payload_allocated_size);
+    mr_.deallocate(std::get<1>(fields), std::get<2>(fields));
+
+    fields = payload.release();
+    EXPECT_THAT(std::get<0>(fields), 0);
+    EXPECT_THAT(std::get<1>(fields), nullptr);
+    EXPECT_THAT(std::get<2>(fields), 0);
+}
+
+TEST_F(TestMediaPayload, reset)
+{
+    constexpr std::size_t payload_size           = 5;
+    constexpr std::size_t payload_allocated_size = 8;
+    auto* const           payload_data           = static_cast<cetl::byte*>(mr_.allocate(payload_allocated_size));
+
+    MediaPayload payload{payload_size, payload_data, payload_allocated_size, &mr_};
+
+    payload.reset();
+    EXPECT_THAT(payload.getSpan().size(), 0);
+    EXPECT_THAT(payload.getSpan().data(), nullptr);
+    EXPECT_THAT(payload.getAllocatedSize(), 0);
+
+    payload.reset();
+    EXPECT_THAT(payload.getSpan().size(), 0);
+    EXPECT_THAT(payload.getSpan().data(), nullptr);
+    EXPECT_THAT(payload.getAllocatedSize(), 0);
+}
+
+}  // namespace


### PR DESCRIPTION
- Introduced `libcyphal::transport::MediaPayload` - in use to pass payload data between the transport layer and its media.
- Use lates latest Canard v4 api