### PR TITLE
Issue/352 single TX copy

### DIFF
--- a/cmake/modules/Findlibcanard.cmake
+++ b/cmake/modules/Findlibcanard.cmake
@@ -9,7 +9,7 @@
 include(FetchContent)
 
 set(libcanard_GIT_REPOSITORY "https://github.com/OpenCyphal/libcanard.git")
-set(libcanard_GIT_TAG "03fc5fecc2c81bd6bfc6e474af8059fca2db4647")
+set(libcanard_GIT_TAG "v4")
 
 FetchContent_Declare(
     libcanard

--- a/cmake/modules/Findlibudpard.cmake
+++ b/cmake/modules/Findlibudpard.cmake
@@ -9,7 +9,7 @@ include(FindPackageHandleStandardArgs)
 include(ProjectLibrary)
 
 set(libudpard_GIT_REPOSITORY "https://github.com/OpenCyphal-garage/libudpard.git")
-set(libudpard_GIT_TAG "1.0.1")
+set(libudpard_GIT_TAG "v2")
 
 FetchContent_Declare(
     libudpard

--- a/docs/examples/0_transport/example_0_transport_2_heartbeat_getinfo_linux_can.cpp
+++ b/docs/examples/0_transport/example_0_transport_2_heartbeat_getinfo_linux_can.cpp
@@ -122,9 +122,9 @@ TEST_F(Example_0_Transport_2_Heartbeat_GetInfo_Can, main)
 {
     State state{mr_};
 
-    // Make CAN transport with collection of media.
+    // Make CAN transport with a collection of media.
     //
-    if (!state.media_collection_.make(mr_, executor_, iface_addresses_))
+    if (!state.media_collection_.make(mr_, executor_, iface_addresses_, mr_))
     {
         GTEST_SKIP();
     }

--- a/docs/examples/0_transport/example_0_transport_2_heartbeat_getinfo_linux_can.cpp
+++ b/docs/examples/0_transport/example_0_transport_2_heartbeat_getinfo_linux_can.cpp
@@ -124,7 +124,7 @@ TEST_F(Example_0_Transport_2_Heartbeat_GetInfo_Can, main)
 
     // Make CAN transport with collection of media.
     //
-    if (!state.media_collection_.make(executor_, iface_addresses_))
+    if (!state.media_collection_.make(mr_, executor_, iface_addresses_))
     {
         GTEST_SKIP();
     }

--- a/docs/examples/1_presentation/example_1_presentation_3_hb_getinfo_ping_linux_can.cpp
+++ b/docs/examples/1_presentation/example_1_presentation_3_hb_getinfo_ping_linux_can.cpp
@@ -297,7 +297,7 @@ TEST_F(Example_1_Presentation_3_HB_GetInfo_Ping_Can, main)
 
     // 1. Make CAN transport with collection of media.
     //
-    if (!state.media_collection_.make(executor_, iface_addresses_))
+    if (!state.media_collection_.make(mr_, executor_, iface_addresses_))
     {
         GTEST_SKIP();
     }

--- a/docs/examples/1_presentation/example_1_presentation_3_hb_getinfo_ping_linux_can.cpp
+++ b/docs/examples/1_presentation/example_1_presentation_3_hb_getinfo_ping_linux_can.cpp
@@ -295,9 +295,9 @@ TEST_F(Example_1_Presentation_3_HB_GetInfo_Ping_Can, main)
     std::cout << "Remote node ID: " << remote_node_id_ << "\n";
     std::cout << "Interfaces    : '" << CommonHelpers::joinInterfaceAddresses(iface_addresses_) << "'\n";
 
-    // 1. Make CAN transport with collection of media.
+    // 1. Make CAN transport with a collection of media.
     //
-    if (!state.media_collection_.make(mr_, executor_, iface_addresses_))
+    if (!state.media_collection_.make(mr_, executor_, iface_addresses_, mr_))
     {
         GTEST_SKIP();
     }

--- a/docs/examples/platform/linux/can/can_media.hpp
+++ b/docs/examples/platform/linux/can/can_media.hpp
@@ -45,20 +45,22 @@ public:
     {
         Collection() = default;
 
-        bool make(libcyphal::IExecutor& executor, std::vector<std::string>& iface_addresses)
+        bool make(cetl::pmr::memory_resource& memory,
+                  libcyphal::IExecutor&       executor,
+                  std::vector<std::string>&   iface_addresses)
         {
             reset();
 
             for (const auto& iface_address : iface_addresses)
             {
-                auto maybe_media = CanMedia::make(executor, iface_address);
+                auto maybe_media = CanMedia::make(memory, executor, iface_address);
                 if (auto* const error = cetl::get_if<libcyphal::transport::PlatformError>(&maybe_media))
                 {
                     std::cerr << "Failed to create CAN media '" << iface_address << "', errno=" << (*error)->code()
                               << ".";
                     return false;
                 }
-                media_vector_.emplace_back(cetl::get<Linux::CanMedia>(std::move(maybe_media)));
+                media_vector_.emplace_back(cetl::get<CanMedia>(std::move(maybe_media)));
             }
 
             for (auto& media : media_vector_)
@@ -87,8 +89,9 @@ public:
     };  // Collection
 
     CETL_NODISCARD static cetl::variant<CanMedia, libcyphal::transport::PlatformError> make(
-        libcyphal::IExecutor& executor,
-        const std::string&    iface_address)
+        cetl::pmr::memory_resource& memory,
+        libcyphal::IExecutor&       executor,
+        const std::string&          iface_address)
     {
         const SocketCANFD socket_can_rx_fd = ::socketcanOpen(iface_address.c_str(), false);
         if (socket_can_rx_fd < 0)
@@ -107,7 +110,7 @@ public:
             return libcyphal::transport::PlatformError{posix::PosixPlatformError{error_code}};
         }
 
-        return CanMedia{executor, socket_can_rx_fd, socket_can_tx_fd, iface_address};
+        return CanMedia{memory, executor, socket_can_rx_fd, socket_can_tx_fd, iface_address};
     }
 
     ~CanMedia()
@@ -126,7 +129,8 @@ public:
     CanMedia& operator=(const CanMedia&) = delete;
 
     CanMedia(CanMedia&& other) noexcept
-        : executor_{other.executor_}
+        : memory_{other.memory_}
+        , executor_{other.executor_}
         , socket_can_rx_fd_{std::exchange(other.socket_can_rx_fd_, -1)}
         , socket_can_tx_fd_{std::exchange(other.socket_can_tx_fd_, -1)}
         , iface_address_{other.iface_address_}
@@ -164,11 +168,13 @@ private:
     using Filter  = libcyphal::transport::can::Filter;
     using Filters = libcyphal::transport::can::Filters;
 
-    CanMedia(libcyphal::IExecutor& executor,
-             const SocketCANFD     socket_can_rx_fd,
-             const SocketCANFD     socket_can_tx_fd,
-             std::string           iface_address)
-        : executor_{executor}
+    CanMedia(cetl::pmr::memory_resource& memory,
+             libcyphal::IExecutor&       executor,
+             const SocketCANFD           socket_can_rx_fd,
+             const SocketCANFD           socket_can_tx_fd,
+             std::string                 iface_address)
+        : memory_{memory}
+        , executor_{executor}
         , socket_can_rx_fd_{socket_can_rx_fd}
         , socket_can_tx_fd_{socket_can_tx_fd}
         , iface_address_{std::move(iface_address)}
@@ -215,7 +221,7 @@ private:
                           const libcyphal::transport::can::CanId can_id,
                           const cetl::span<const cetl::byte>     payload) noexcept override
     {
-        const CanardFrame  canard_frame{can_id, payload.size(), payload.data()};
+        const CanardFrame  canard_frame{can_id, {payload.size(), payload.data()}};
         const std::int16_t result = ::socketcanPush(socket_can_tx_fd_, &canard_frame, 0);
         if (result < 0)
         {
@@ -247,7 +253,7 @@ private:
             return cetl::nullopt;
         }
 
-        return PopResult::Metadata{executor_.now(), canard_frame.extended_can_id, canard_frame.payload_size};
+        return PopResult::Metadata{executor_.now(), canard_frame.extended_can_id, canard_frame.payload.size};
     }
 
     CETL_NODISCARD libcyphal::IExecutor::Callback::Any registerPushCallback(
@@ -264,12 +270,18 @@ private:
         return registerAwaitableCallback(std::move(function), ReadableTrigger{socket_can_rx_fd_});
     }
 
+    cetl::pmr::memory_resource& getTxMemoryResource() override
+    {
+        return memory_;
+    }
+
     // MARK: Data members:
 
-    libcyphal::IExecutor& executor_;
-    SocketCANFD           socket_can_rx_fd_;
-    SocketCANFD           socket_can_tx_fd_;
-    const std::string     iface_address_;
+    cetl::pmr::memory_resource& memory_;
+    libcyphal::IExecutor&       executor_;
+    SocketCANFD                 socket_can_rx_fd_;
+    SocketCANFD                 socket_can_tx_fd_;
+    const std::string           iface_address_;
 
 };  // CanMedia
 

--- a/docs/examples/platform/linux/can/socketcan.c
+++ b/docs/examples/platform/linux/can/socketcan.c
@@ -133,7 +133,7 @@ SocketCANFD socketcanOpen(const char* const iface_name, const bool can_fd)
     return getNegatedErrno();
 }
 
-int16_t socketcanPush(const SocketCANFD fd, const CanardFrame* const frame, const CanardMicrosecond timeout_usec)
+int16_t socketcanPush(const SocketCANFD fd, const struct CanardFrame* const frame, const CanardMicrosecond timeout_usec)
 {
     if ((frame == NULL) || (frame->payload.data == NULL) || (frame->payload.size > UINT8_MAX))
     {
@@ -166,7 +166,7 @@ int16_t socketcanPush(const SocketCANFD fd, const CanardFrame* const frame, cons
 }
 
 int16_t socketcanPop(const SocketCANFD        fd,
-                     CanardFrame* const       out_frame,
+                     struct CanardFrame* const       out_frame,
                      CanardMicrosecond* const out_timestamp_usec,
                      const size_t             payload_buffer_size,
                      void* const              payload_buffer,
@@ -262,7 +262,7 @@ int16_t socketcanPop(const SocketCANFD        fd,
                 return -EIO;
             }
 
-            (void) memset(out_frame, 0, sizeof(CanardFrame));
+            (void) memset(out_frame, 0, sizeof(struct CanardFrame));
             *out_timestamp_usec = (CanardMicrosecond) (((uint64_t) tv.tv_sec * MEGA) + (uint64_t) tv.tv_usec);
         }
         out_frame->extended_can_id = sockcan_frame.can_id & CAN_EFF_MASK;
@@ -273,7 +273,7 @@ int16_t socketcanPop(const SocketCANFD        fd,
     return poll_result;
 }
 
-int16_t socketcanFilter(const SocketCANFD fd, const size_t num_configs, const CanardFilter* const configs)
+int16_t socketcanFilter(const SocketCANFD fd, const size_t num_configs, const struct CanardFilter* const configs)
 {
     if (configs == NULL)
     {

--- a/docs/examples/platform/linux/can/socketcan.c
+++ b/docs/examples/platform/linux/can/socketcan.c
@@ -7,6 +7,7 @@
 #    define _GNU_SOURCE
 #endif
 
+#include "canard.h"
 #include "socketcan.h"
 
 #ifdef __linux__

--- a/docs/examples/platform/linux/can/socketcan.c
+++ b/docs/examples/platform/linux/can/socketcan.c
@@ -134,7 +134,7 @@ SocketCANFD socketcanOpen(const char* const iface_name, const bool can_fd)
 
 int16_t socketcanPush(const SocketCANFD fd, const CanardFrame* const frame, const CanardMicrosecond timeout_usec)
 {
-    if ((frame == NULL) || (frame->payload == NULL) || (frame->payload_size > UINT8_MAX))
+    if ((frame == NULL) || (frame->payload.data == NULL) || (frame->payload.size > UINT8_MAX))
     {
         return -EINVAL;
     }
@@ -147,15 +147,15 @@ int16_t socketcanPush(const SocketCANFD fd, const CanardFrame* const frame, cons
         struct canfd_frame cfd;
         (void) memset(&cfd, 0, sizeof(cfd));
         cfd.can_id = frame->extended_can_id | CAN_EFF_FLAG;
-        cfd.len    = (uint8_t) frame->payload_size;
+        cfd.len    = (uint8_t) frame->payload.size;
         // We set the bit rate switch on the assumption that it will be ignored by non-CAN-FD-capable hardware.
         cfd.flags = CANFD_BRS;
-        (void) memcpy(cfd.data, frame->payload, frame->payload_size);
+        (void) memcpy(cfd.data, frame->payload.data, frame->payload.size);
 
         // If the payload is small, use the smaller MTU for compatibility with non-FD sockets.
         // This way, if the user attempts to transmit a CAN FD frame without having the CAN FD socket option enabled,
         // an error will be triggered here.  This is convenient -- we can handle both FD and Classic CAN uniformly.
-        const size_t mtu = (frame->payload_size > CAN_MAX_DLEN) ? CANFD_MTU : CAN_MTU;
+        const size_t mtu = (frame->payload.size > CAN_MAX_DLEN) ? CANFD_MTU : CAN_MTU;
         if (write(fd, &cfd, mtu) < 0)
         {
             return getNegatedErrno();
@@ -265,8 +265,8 @@ int16_t socketcanPop(const SocketCANFD        fd,
             *out_timestamp_usec = (CanardMicrosecond) (((uint64_t) tv.tv_sec * MEGA) + (uint64_t) tv.tv_usec);
         }
         out_frame->extended_can_id = sockcan_frame.can_id & CAN_EFF_MASK;
-        out_frame->payload_size    = sockcan_frame.len;
-        out_frame->payload         = payload_buffer;
+        out_frame->payload.size    = sockcan_frame.len;
+        out_frame->payload.data    = payload_buffer;
         (void) memcpy(payload_buffer, &sockcan_frame.data[0], sockcan_frame.len);
     }
     return poll_result;

--- a/docs/examples/platform/linux/can/socketcan.h
+++ b/docs/examples/platform/linux/can/socketcan.h
@@ -53,7 +53,7 @@ SocketCANFD socketcanOpen(const char* const iface_name, const bool can_fd);
 /// Block until the frame is enqueued or until the timeout is expired.
 /// Zero timeout makes the operation non-blocking.
 /// Returns 1 on success, 0 on timeout, negated errno on error.
-int16_t socketcanPush(const SocketCANFD fd, const CanardFrame* const frame, const CanardMicrosecond timeout_usec);
+int16_t socketcanPush(const SocketCANFD fd, const struct CanardFrame* const frame, const CanardMicrosecond timeout_usec);
 
 /// Fetch a new extended CAN data frame from the RX queue.
 /// If the received frame is not an extended-ID data frame, it will be dropped and the function will return early.
@@ -67,7 +67,7 @@ int16_t socketcanPush(const SocketCANFD fd, const CanardFrame* const frame, cons
 /// Zero timeout makes the operation non-blocking.
 /// Returns 1 on success, 0 on timeout, negated errno on error.
 int16_t socketcanPop(const SocketCANFD        fd,
-                     CanardFrame* const       out_frame,
+                     struct CanardFrame* const       out_frame,
                      CanardMicrosecond* const out_timestamp_usec,
                      const size_t             payload_buffer_size,
                      void* const              payload_buffer,
@@ -78,7 +78,7 @@ int16_t socketcanPop(const SocketCANFD        fd,
 /// Note that it is only possible to accept extended-format data frames.
 /// The default configuration is to accept everything.
 /// Returns 0 on success, negated errno on error.
-int16_t socketcanFilter(const SocketCANFD fd, const size_t num_configs, const CanardFilter* const configs);
+int16_t socketcanFilter(const SocketCANFD fd, const size_t num_configs, const struct CanardFilter* const configs);
 
 #ifdef __cplusplus
 }

--- a/docs/examples/platform/posix/udp/udp_media.hpp
+++ b/docs/examples/platform/posix/udp/udp_media.hpp
@@ -96,6 +96,11 @@ private:
         return UdpRxSocket::make(memory_, executor_, iface_address_, multicast_endpoint);
     }
 
+    cetl::pmr::memory_resource& getTxMemoryResource() override
+    {
+        return memory_;
+    }
+
     // MARK: Data members:
 
     cetl::pmr::memory_resource& memory_;

--- a/docs/examples/platform/tracking_memory_resource.hpp
+++ b/docs/examples/platform/tracking_memory_resource.hpp
@@ -79,6 +79,7 @@ private:
             CETL_DEBUG_ASSERT(prev_alloc != allocations.cend(), "");
             if (prev_alloc != allocations.cend())
             {
+                CETL_DEBUG_ASSERT(prev_alloc->size == size_bytes, "");
                 allocations.erase(prev_alloc);
             }
             total_deallocated_bytes += size_bytes;
@@ -106,6 +107,7 @@ private:
             CETL_DEBUG_ASSERT(prev_alloc != allocations.cend(), "");
             if (prev_alloc != allocations.cend())
             {
+                CETL_DEBUG_ASSERT(prev_alloc->size == old_size_bytes, "");
                 allocations.erase(prev_alloc);
             }
             total_allocated_bytes -= old_size_bytes;

--- a/include/libcyphal/transport/can/delegate.hpp
+++ b/include/libcyphal/transport/can/delegate.hpp
@@ -216,7 +216,7 @@ public:
     TransportDelegate& operator=(const TransportDelegate&)     = delete;
     TransportDelegate& operator=(TransportDelegate&&) noexcept = delete;
 
-    CETL_NODISCARD NodeId node_id() const noexcept
+    CETL_NODISCARD NodeId getNodeId() const noexcept
     {
         return canard_instance_.node_id;
     }
@@ -226,12 +226,12 @@ public:
         canard_instance_.node_id = static_cast<CanardNodeID>(node_id);
     }
 
-    CETL_NODISCARD CanardInstance& canard_instance() noexcept
+    CETL_NODISCARD CanardInstance& canardInstance() noexcept
     {
         return canard_instance_;
     }
 
-    CETL_NODISCARD const CanardInstance& canard_instance() const noexcept
+    CETL_NODISCARD const CanardInstance& canardInstance() const noexcept
     {
         return canard_instance_;
     }
@@ -280,10 +280,10 @@ public:
     /// @param tx_item The TX queue item to be popped and freed.
     /// @param whole_transfer If `true` then whole transfer should be released from the queue.
     ///
-    static void popAndFreeCanardTxQueueItem(CanardTxQueue&           tx_queue,
-                                            const CanardInstance&    canard_instance,
-                                            const CanardTxQueueItem* tx_item,
-                                            const bool               whole_transfer)
+    static void popAndFreeCanardTxQueueItem(CanardTxQueue&        tx_queue,
+                                            const CanardInstance& canard_instance,
+                                            CanardTxQueueItem*    tx_item,
+                                            const bool            whole_transfer)
     {
         while (CanardTxQueueItem* const mut_tx_item = ::canardTxPop(&tx_queue, tx_item))
         {
@@ -317,7 +317,7 @@ protected:
         , canard_instance_{::canardInit(makeCanardMemoryResource())}
     {
         // No Sonar `cpp:S5356` b/c we integrate here with C libcanard API.
-        canard_instance().user_reference = this;  // NOSONAR cpp:S5356
+        canardInstance().user_reference = this;  // NOSONAR cpp:S5356
     }
 
     ~TransportDelegate() = default;

--- a/include/libcyphal/transport/can/delegate.hpp
+++ b/include/libcyphal/transport/can/delegate.hpp
@@ -49,14 +49,19 @@ public:
     class CanardMemory final : public ScatteredBuffer::IStorage  // NOSONAR cpp:S4963
     {
     public:
-        CanardMemory(TransportDelegate& delegate, cetl::byte* const buffer, const std::size_t payload_size)
+        CanardMemory(TransportDelegate& delegate,
+                     const std::size_t  allocated_size,
+                     cetl::byte* const  buffer,
+                     const std::size_t  payload_size)
             : delegate_{delegate}
+            , allocated_size_{allocated_size}
             , buffer_{buffer}
             , payload_size_{payload_size}
         {
         }
         CanardMemory(CanardMemory&& other) noexcept
             : delegate_{other.delegate_}
+            , allocated_size_{std::exchange(other.allocated_size_, 0)}
             , buffer_{std::exchange(other.buffer_, nullptr)}
             , payload_size_{std::exchange(other.payload_size_, 0)}
         {
@@ -68,7 +73,7 @@ public:
             if (buffer_ != nullptr)
             {
                 // No Sonar `cpp:S5356` b/c we integrate here with C libcanard memory management.
-                delegate_.freeCanardMemory(buffer_);  // NOSONAR cpp:S5356
+                delegate_.freeCanardMemory(buffer_, allocated_size_);  // NOSONAR cpp:S5356
             }
         }
 
@@ -106,6 +111,7 @@ public:
         // MARK: Data members:
 
         TransportDelegate& delegate_;
+        std::size_t        allocated_size_;
         cetl::byte*        buffer_;
         std::size_t        payload_size_;
 
@@ -183,7 +189,7 @@ public:
     private:
         static Node& down(CanardTreeNode& node)
         {
-            // Next nolint & NOSONAR are unavoidable: this is integration with low-level C code of Canard AVL trees.
+            // Next nolint & NOSONAR are unavoidable: this is integration with Canard C AVL trees.
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             return reinterpret_cast<Node&>(node);  // NOSONAR cpp:S3630
         }
@@ -250,21 +256,16 @@ public:
     /// @brief Releases memory allocated for canard (by previous `allocateMemoryForCanard` call).
     ///
     /// No Sonar `cpp:S5008` and `cpp:S5356` b/c they are unavoidable -
-    /// this is integration with low-level C code of Canard memory management.
+    /// this is integration with low-level Canard C memory management.
     ///
-    void freeCanardMemory(void* const pointer) const  // NOSONAR cpp:S5008
+    void freeCanardMemory(void* const pointer, const std::size_t amount) const  // NOSONAR cpp:S5008
     {
         if (pointer == nullptr)
         {
             return;
         }
 
-        auto* memory_header = static_cast<CanardMemoryHeader*>(pointer);  // NOSONAR cpp:S5356
-        // Next nolint is unavoidable: this is integration with C code of Canard memory management.
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        --memory_header;
-
-        memory_.deallocate(memory_header, memory_header->size);  // NOSONAR cpp:S5356
+        memory_.deallocate(pointer, amount);
     }
 
     /// Pops and frees Canard TX queue item(s).
@@ -273,16 +274,18 @@ public:
     /// @param tx_item The TX queue item to be popped and freed.
     /// @param whole_transfer If `true` then whole transfer should be released from the queue.
     ///
-    void popAndFreeCanardTxQueueItem(CanardTxQueue* const     tx_queue,
-                                     const CanardTxQueueItem* tx_item,
-                                     const bool               whole_transfer) const
+    static void popAndFreeCanardTxQueueItem(CanardTxQueue&           tx_queue,
+                                            const CanardTxQueueItem* tx_item,
+                                            const bool               whole_transfer)
     {
-        while (CanardTxQueueItem* const mut_tx_item = ::canardTxPop(tx_queue, tx_item))
+        while (CanardTxQueueItem* const mut_tx_item = ::canardTxPop(&tx_queue, tx_item))
         {
             tx_item = tx_item->next_in_transfer;
 
             // No Sonar `cpp:S5356` b/c we need to free tx item allocated by libcanard as a raw memory.
-            freeCanardMemory(mut_tx_item);  // NOSONAR cpp:S5356
+            tx_queue.memory.deallocate(tx_queue.memory.user_reference,
+                                       mut_tx_item->allocated_size,
+                                       mut_tx_item);  // NOSONAR cpp:S5356
 
             if (!whole_transfer)
             {
@@ -308,7 +311,7 @@ public:
 protected:
     explicit TransportDelegate(cetl::pmr::memory_resource& memory)
         : memory_{memory}
-        , canard_instance_{::canardInit(allocateMemoryForCanard, freeCanardMemory)}
+        , canard_instance_{::canardInit(makeCanardMemoryResource())}
     {
         // No Sonar `cpp:S5356` b/c we integrate here with C libcanard API.
         canard_instance().user_reference = this;  // NOSONAR cpp:S5356
@@ -317,72 +320,47 @@ protected:
     ~TransportDelegate() = default;
 
 private:
-    // Until "canardMemFree must provide size" issue #216 is resolved,
-    // we need to store the size of the memory allocated.
-    // TODO: Remove this workaround when the issue is resolved.
-    // see https://github.com/OpenCyphal/libcanard/issues/216
-    //
-    struct CanardMemoryHeader final
-    {
-        alignas(std::max_align_t) std::size_t size;
-    };
-
     /// @brief Converts Canard instance to the transport delegate.
     ///
     /// In use to bridge two worlds: canard library and transport entities.
+    /// NOSONAR  cpp:S5008 is unavoidable: this is integration with low-level Canard C memory management.
     ///
-    CETL_NODISCARD static TransportDelegate& getSelfFrom(const CanardInstance* const ins)
+    CETL_NODISCARD static TransportDelegate& getSelfFrom(void* const user_reference)  // NOSONAR cpp:S5008
     {
-        CETL_DEBUG_ASSERT(ins != nullptr, "Expected canard instance.");
-        CETL_DEBUG_ASSERT(ins->user_reference != nullptr, "Expected `this` transport as user reference.");
+        CETL_DEBUG_ASSERT(user_reference != nullptr, "Expected `this` transport as user reference.");
 
         // No Sonar `cpp:S5357` b/c the raw `user_reference` is part of libcanard api,
         // and it was set by us at this delegate constructor (see `TransportDelegate` ctor).
-        return *static_cast<TransportDelegate*>(ins->user_reference);  // NOSONAR cpp:S5357
+        return *static_cast<TransportDelegate*>(user_reference);  // NOSONAR cpp:S5357
     }
 
     /// @brief Allocates memory for canard instance.
     ///
-    /// Implicitly stores the size of the allocated memory in the prepended `CanardMemoryHeader` struct,
-    /// so that it will possible later (at `freeCanardMemory`) restore the original size.
+    /// NOSONAR  cpp:S5008 is unavoidable: this is integration with low-level Canard C memory management.
     ///
-    /// NOSONAR cpp:S995 is unavoidable: this is integration with low-level C code
-    /// of Canard memory management (@see ::canardInit).
-    ///
-    CETL_NODISCARD static void* allocateMemoryForCanard(CanardInstance* ins, std::size_t amount)  // NOSONAR cpp:S995
+    CETL_NODISCARD static void* allocateMemoryForCanard(void* const       user_reference,  // NOSONAR cpp:S5008
+                                                        const std::size_t amount)
     {
-        TransportDelegate& self = getSelfFrom(ins);
-
-        const std::size_t memory_size = sizeof(CanardMemoryHeader) + amount;
-
-        // No Sonar `cpp:S5356` and `cpp:S5357` b/c we integrate here with C libcanard memory management.
-        auto* memory_header =
-            static_cast<CanardMemoryHeader*>(self.memory_.allocate(memory_size));  // NOSONAR cpp:S5356 cpp:S5357
-        if (memory_header == nullptr)
-        {
-            return nullptr;
-        }
-
-        // Return the memory after the `CanardMemoryHeader` struct (containing its size).
-        // The size is used in `canardMemoryFree` to deallocate the memory.
-        //
-        memory_header->size = memory_size;
-        // Next nolint and no Sonar `cpp:S5356` are unavoidable -
-        // this is integration with C code of Canard memory management.
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        return ++memory_header;  // NOSONAR cpp:S5356
+        const TransportDelegate& self = getSelfFrom(user_reference);
+        return self.memory_.allocate(amount);
     }
 
     /// @brief Releases memory allocated for canard instance (by previous `allocateMemoryForCanard` call).
     ///
-    /// NOSONAR cpp:S995 & cpp:S5008 are unavoidable: this is integration with low-level C code
-    /// of Canard memory management (@see ::canardInit).
+    /// NOSONAR  cpp:S5008 is unavoidable: this is integration with low-level Canard C memory management.
     ///
-    static void freeCanardMemory(CanardInstance* ins,  // NOSONAR cpp:S995
-                                 void*           pointer)        // NOSONAR cpp:S5008
+    static void freeCanardMemory(void* const       user_reference,  // NOSONAR cpp:S5008
+                                 const std::size_t amount,
+                                 void* const       pointer)  // NOSONAR cpp:S5008
     {
-        const TransportDelegate& self = getSelfFrom(ins);
-        self.freeCanardMemory(pointer);
+        const TransportDelegate& self = getSelfFrom(user_reference);
+        self.freeCanardMemory(pointer, amount);
+    }
+
+    CETL_NODISCARD CanardMemoryResource makeCanardMemoryResource()
+    {
+        // No Sonar `cpp:S5356` b/c we integrate here with C libcanard memory management.
+        return {this, freeCanardMemory, allocateMemoryForCanard};  // NOSONAR cpp:S5356
     }
 
     // MARK: Data members:

--- a/include/libcyphal/transport/can/media.hpp
+++ b/include/libcyphal/transport/can/media.hpp
@@ -68,8 +68,8 @@ public:
     /// @brief Schedules the frame for transmission asynchronously and return immediately.
     ///
     /// Concrete media implementation has multiple options with how to handle `payload` buffer:
-    /// - just copy the buffer data byts (using `payload.getSpan` const method) and return without changing the payload;
-    /// - take ownership of the buffer (by moving the payload to another internal payload;
+    /// - just copy the buffer data bytes (using `payload.getSpan()` method) and return without changing the payload;
+    /// - take ownership of the buffer (by moving the payload to another internal payload);
     /// - calling `payload.reset()` immediately after it's not needed anymore.
     /// In any case, the payload should not be changed (moved or reset) if it is not accepted.
     ///

--- a/include/libcyphal/transport/can/media.hpp
+++ b/include/libcyphal/transport/can/media.hpp
@@ -8,6 +8,7 @@
 
 #include "libcyphal/executor.hpp"
 #include "libcyphal/transport/errors.hpp"
+#include "libcyphal/transport/media_payload.hpp"
 #include "libcyphal/types.hpp"
 
 #include <cetl/cetl.hpp>
@@ -66,9 +67,16 @@ public:
 
     /// @brief Schedules the frame for transmission asynchronously and return immediately.
     ///
+    /// Concrete media implementation has multiple options with how to handle `payload` buffer:
+    /// - just copy the buffer data byts (using `payload.getSpan` const method) and return without changing the payload;
+    /// - take ownership of the buffer (by moving the payload to another internal payload;
+    /// - calling `payload.reset()` immediately after it's not needed anymore.
+    /// In any case, the payload should not be changed (moved or reset) if it is not accepted.
+    ///
     /// @param deadline The deadline for the push operation. Media implementation should drop the payload
     ///                 if the deadline is exceeded (aka `now > deadline`).
     /// @param can_id The destination CAN ID of the frame.
+    /// @param payload The mutable payload of the frame. Should not be changed if payload is not accepted.
     /// @return `true` if the frame is accepted or already timed out;
     ///         `false` to try again later (f.e. b/c output TX queue is currently full).
     ///         If any media failure occurred, the frame will be dropped by transport.
@@ -83,9 +91,7 @@ public:
 
         using Type = Expected<Success, Failure>;
     };
-    virtual PushResult::Type push(const TimePoint                    deadline,
-                                  const CanId                        can_id,
-                                  const cetl::span<const cetl::byte> payload) noexcept = 0;
+    virtual PushResult::Type push(const TimePoint deadline, const CanId can_id, MediaPayload& payload) noexcept = 0;
     ///@}
 
     /// @brief Takes the next payload fragment (aka CAN frame) from the reception queue unless it's empty.

--- a/include/libcyphal/transport/can/media.hpp
+++ b/include/libcyphal/transport/can/media.hpp
@@ -137,6 +137,18 @@ public:
     ///
     CETL_NODISCARD virtual IExecutor::Callback::Any registerPopCallback(IExecutor::Callback::Function&& function) = 0;
 
+    /// Gets the memory resource for the TX frame payload buffers.
+    ///
+    /// The lizard or the client can both allocate and deallocate memory using this memory resource.
+    /// The TX memory resource (MR) will be used to allocate memory for the lizard when it needs to enqueue a new TX
+    /// item. If that item never makes it to the IMedia (for example, if it times out or the transmission is canceled
+    /// for other reasons like running out of queue space or memory), the memory is freed using the same MR. If the item
+    /// actually makes it to IMedia, the `ITxSocket::send` takes ownership of the buffer, so that the client doesn't
+    /// need to free it. What happens to the buffer afterward is none of the client's concerns, the media will take care
+    /// of everything.
+    ///
+    virtual cetl::pmr::memory_resource& getTxMemoryResource() = 0;
+
 protected:
     IMedia()  = default;
     ~IMedia() = default;

--- a/include/libcyphal/transport/can/msg_rx_session.hpp
+++ b/include/libcyphal/transport/can/msg_rx_session.hpp
@@ -156,8 +156,11 @@ private:
                 : cetl::make_optional<NodeId>(transfer.metadata.remote_node_id);
 
         // No Sonar `cpp:S5356` and `cpp:S5357` b/c we need to pass raw data from C libcanard api.
-        auto* const buffer = static_cast<cetl::byte*>(transfer.payload);  // NOSONAR cpp:S5356 cpp:S5357
-        TransportDelegate::CanardMemory canard_memory{delegate_, buffer, transfer.payload_size};
+        auto* const buffer = static_cast<cetl::byte*>(transfer.payload.data);  // NOSONAR cpp:S5356 cpp:S5357
+        TransportDelegate::CanardMemory canard_memory{delegate_,
+                                                      transfer.payload.allocated_size,
+                                                      buffer,
+                                                      transfer.payload.size};
 
         const MessageRxMetadata meta{{{transfer_id, priority}, timestamp}, publisher_node_id};
         MessageRxTransfer       msg_rx_transfer{meta, ScatteredBuffer{std::move(canard_memory)}};

--- a/include/libcyphal/transport/can/msg_rx_session.hpp
+++ b/include/libcyphal/transport/can/msg_rx_session.hpp
@@ -75,7 +75,7 @@ public:
         , params_{params}
         , subscription_{}
     {
-        const std::int8_t result = ::canardRxSubscribe(&delegate.canard_instance(),
+        const std::int8_t result = ::canardRxSubscribe(&delegate.canardInstance(),
                                                        CanardTransferKindMessage,
                                                        params_.subject_id,
                                                        params_.extent_bytes,
@@ -99,7 +99,7 @@ public:
     ~MessageRxSession()
     {
         const std::int8_t result =
-            ::canardRxUnsubscribe(&delegate_.canard_instance(), CanardTransferKindMessage, params_.subject_id);
+            ::canardRxUnsubscribe(&delegate_.canardInstance(), CanardTransferKindMessage, params_.subject_id);
         (void) result;
         CETL_DEBUG_ASSERT(result >= 0, "There is no way currently to get an error here.");
         CETL_DEBUG_ASSERT(result > 0, "Subscription supposed to be made at constructor.");

--- a/include/libcyphal/transport/can/svc_rx_sessions.hpp
+++ b/include/libcyphal/transport/can/svc_rx_sessions.hpp
@@ -159,8 +159,11 @@ private:
         const auto timestamp      = TimePoint{std::chrono::microseconds{transfer.timestamp_usec}};
 
         // No Sonar `cpp:S5356` and `cpp:S5357` b/c we need to pass raw data from C libcanard api.
-        auto* const buffer = static_cast<cetl::byte*>(transfer.payload);  // NOSONAR cpp:S5356 cpp:S5357
-        TransportDelegate::CanardMemory canard_memory{delegate_, buffer, transfer.payload_size};
+        auto* const buffer = static_cast<cetl::byte*>(transfer.payload.data);  // NOSONAR cpp:S5356 cpp:S5357
+        TransportDelegate::CanardMemory canard_memory{delegate_,
+                                                      transfer.payload.allocated_size,
+                                                      buffer,
+                                                      transfer.payload.size};
 
         const ServiceRxMetadata meta{{{transfer_id, priority}, timestamp}, remote_node_id};
         ServiceRxTransfer       svc_rx_transfer{meta, ScatteredBuffer{std::move(canard_memory)}};

--- a/include/libcyphal/transport/can/svc_rx_sessions.hpp
+++ b/include/libcyphal/transport/can/svc_rx_sessions.hpp
@@ -82,7 +82,7 @@ public:
         , params_{params}
         , subscription_{}
     {
-        const std::int8_t result = ::canardRxSubscribe(&delegate.canard_instance(),
+        const std::int8_t result = ::canardRxSubscribe(&delegate.canardInstance(),
                                                        TransferKind,
                                                        params_.service_id,
                                                        params_.extent_bytes,
@@ -105,8 +105,7 @@ public:
 
     ~SvcRxSession()
     {
-        const std::int8_t result =
-            ::canardRxUnsubscribe(&delegate_.canard_instance(), TransferKind, params_.service_id);
+        const std::int8_t result = ::canardRxUnsubscribe(&delegate_.canardInstance(), TransferKind, params_.service_id);
         (void) result;
         CETL_DEBUG_ASSERT(result >= 0, "There is no way currently to get an error here.");
         CETL_DEBUG_ASSERT(result > 0, "Subscription supposed to be made at constructor.");

--- a/include/libcyphal/transport/can/svc_tx_sessions.hpp
+++ b/include/libcyphal/transport/can/svc_tx_sessions.hpp
@@ -82,7 +82,7 @@ private:
         // Otherwise, transport may do some work (like possible payload allocation/copying,
         // media enumeration and pushing into their TX queues) doomed to fail with argument error.
         //
-        if (delegate_.node_id() > CANARD_NODE_ID_MAX)
+        if (delegate_.getNodeId() > CANARD_NODE_ID_MAX)
         {
             return ArgumentError{};
         }
@@ -157,7 +157,7 @@ private:
         // Otherwise, transport may do some work (like possible payload allocation/copying,
         // media enumeration and pushing into their TX queues) doomed to fail with argument error.
         //
-        if ((delegate_.node_id() > CANARD_NODE_ID_MAX) || (metadata.remote_node_id > CANARD_NODE_ID_MAX))
+        if ((delegate_.getNodeId() > CANARD_NODE_ID_MAX) || (metadata.remote_node_id > CANARD_NODE_ID_MAX))
         {
             return ArgumentError{};
         }

--- a/include/libcyphal/transport/lizard_helpers.hpp
+++ b/include/libcyphal/transport/lizard_helpers.hpp
@@ -1,0 +1,71 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef LIBCYPHAL_TRANSPORT_LIZARD_HELPERS_HPP_INCLUDED
+#define LIBCYPHAL_TRANSPORT_LIZARD_HELPERS_HPP_INCLUDED
+
+#include <cetl/cetl.hpp>
+#include <cetl/pf17/cetlpf.hpp>
+
+namespace libcyphal
+{
+namespace transport
+{
+
+/// Internal implementation details of a lizard based transport.
+/// Not supposed to be used directly by the users of the library.
+///
+namespace detail
+{
+
+class LizardHelpers final
+{
+public:
+    LizardHelpers() = delete;
+
+    /// Constructs a lizard C memory resource.
+    ///
+    template <typename MemoryResource>
+    CETL_NODISCARD static MemoryResource makeMemoryResource(cetl::pmr::memory_resource& memory)
+    {
+        /// No Sonar `cpp:S5356` is unavoidable - integration with Lizard C memory management.
+        ///
+        return {&memory, deallocateMemory, allocateMemory};  // NOSONAR cpp:S5356
+    }
+
+private:
+    /// No Sonar `cpp:S5008` is unavoidable - integration with Lizard C memory management.
+    ///
+    static void* allocateMemory(void* const user_reference, const std::size_t amount)  // NOSONAR cpp:S5008
+    {
+        // No Sonar `cpp:S5357` "... isn't related to `void*`.
+        // B/c we integrate here with lizard C memory management.
+        auto* const memory = static_cast<cetl::pmr::memory_resource*>(user_reference);  // NOSONAR cpp:S5357
+        CETL_DEBUG_ASSERT(nullptr != user_reference, "Expected PMR as non-null user reference.");
+
+        return memory->allocate(amount);
+    }
+
+    /// No Sonar `cpp:S5008` is unavoidable - integration with Lizard C memory management.
+    ///
+    static void deallocateMemory(void* const       user_reference,  // NOSONAR cpp:S5008
+                                 const std::size_t amount,
+                                 void* const       pointer)  // NOSONAR cpp:S5008
+    {
+        // No Sonar `cpp:S5357` "... isn't related to `void*`.
+        // B/c we integrate here with lizard C memory management.
+        auto* const memory = static_cast<cetl::pmr::memory_resource*>(user_reference);  // NOSONAR cpp:S5357
+        CETL_DEBUG_ASSERT(nullptr != user_reference, "Expected PMR as non-null user reference.");
+
+        memory->deallocate(pointer, amount);
+    }
+
+};  // LizardHelpers
+
+}  // namespace detail
+}  // namespace transport
+}  // namespace libcyphal
+
+#endif  // LIBCYPHAL_TRANSPORT_LIZARD_HELPERS_HPP_INCLUDED

--- a/include/libcyphal/transport/lizard_helpers.hpp
+++ b/include/libcyphal/transport/lizard_helpers.hpp
@@ -27,17 +27,18 @@ public:
 
     /// Constructs a lizard C memory resource.
     ///
-    template <typename MemoryResource>
+    template <typename MemoryResource, std::size_t Alignment = alignof(std::max_align_t)>
     CETL_NODISCARD static MemoryResource makeMemoryResource(cetl::pmr::memory_resource& memory)
     {
         /// No Sonar `cpp:S5356` is unavoidable - integration with Lizard C memory management.
         ///
-        return {&memory, deallocateMemory, allocateMemory};  // NOSONAR cpp:S5356
+        return {&memory, deallocateMemory<Alignment>, allocateMemory<Alignment>};  // NOSONAR cpp:S5356
     }
 
 private:
     /// No Sonar `cpp:S5008` is unavoidable - integration with Lizard C memory management.
     ///
+    template <std::size_t Alignment>
     static void* allocateMemory(void* const user_reference, const std::size_t amount)  // NOSONAR cpp:S5008
     {
         // No Sonar `cpp:S5357` "... isn't related to `void*`.
@@ -45,11 +46,12 @@ private:
         auto* const memory = static_cast<cetl::pmr::memory_resource*>(user_reference);  // NOSONAR cpp:S5357
         CETL_DEBUG_ASSERT(nullptr != user_reference, "Expected PMR as non-null user reference.");
 
-        return memory->allocate(amount);
+        return memory->allocate(amount, Alignment);
     }
 
     /// No Sonar `cpp:S5008` is unavoidable - integration with Lizard C memory management.
     ///
+    template <std::size_t Alignment>
     static void deallocateMemory(void* const       user_reference,  // NOSONAR cpp:S5008
                                  const std::size_t amount,
                                  void* const       pointer)  // NOSONAR cpp:S5008
@@ -59,7 +61,7 @@ private:
         auto* const memory = static_cast<cetl::pmr::memory_resource*>(user_reference);  // NOSONAR cpp:S5357
         CETL_DEBUG_ASSERT(nullptr != user_reference, "Expected PMR as non-null user reference.");
 
-        memory->deallocate(pointer, amount);
+        memory->deallocate(pointer, amount, Alignment);
     }
 
 };  // LizardHelpers

--- a/include/libcyphal/transport/media_payload.hpp
+++ b/include/libcyphal/transport/media_payload.hpp
@@ -1,0 +1,179 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef LIBCYPHAL_TRANSPORT_MEDIA_PAYLOAD_HPP_INCLUDED
+#define LIBCYPHAL_TRANSPORT_MEDIA_PAYLOAD_HPP_INCLUDED
+
+#include <cetl/pf17/cetlpf.hpp>
+#include <cetl/pf20/cetlpf.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+namespace libcyphal
+{
+namespace transport
+{
+
+/// Defines a mutable media payload.
+///
+/// In use to pass payload data between the transport layer and its media.
+/// It also manages memory ownership of the allocated payload buffer.
+///
+class MediaPayload final  // NOSONAR : cpp:S4963 - we do directly handle resources here.
+{
+public:
+    /// Constructs a new empty payload.
+    ///
+    MediaPayload() = default;
+
+    /// Constructs a new payload by owning the provided data buffer.
+    ///
+    /// @param size The size of the payload data in bytes. Must be less or equal to the allocated size.
+    /// @param data The pointer to the payload data buffer.
+    /// @param allocated_size The size of the allocated buffer. Must be greater or equal to the payload size.
+    /// @param mr The PMR which was used to allocate the payload buffer. Will be used to deallocate it.
+    ///
+    MediaPayload(const std::size_t                 size,
+                 cetl::byte* const                 data,
+                 const std::size_t                 allocated_size,
+                 cetl::pmr::memory_resource* const mr)
+        : size_{size}
+        , data_{data}
+        , allocated_size_{allocated_size}
+        , mr_{mr}
+    {
+        CETL_DEBUG_ASSERT(size_ <= allocated_size_, "");
+        CETL_DEBUG_ASSERT((data_ == nullptr) || (mr_ != nullptr), "");
+        CETL_DEBUG_ASSERT((data_ != nullptr) || ((size_ == 0) && (allocated_size_ == 0)), "");
+    }
+
+    /// Moves another payload into this new payload instance.
+    ///
+    /// @param other The other payload to move into.
+    ///
+    MediaPayload(MediaPayload&& other) noexcept
+        : size_{std::exchange(other.size_, 0U)}
+        , data_{std::exchange(other.data_, nullptr)}
+        , allocated_size_{std::exchange(other.allocated_size_, 0U)}
+        , mr_{std::exchange(other.mr_, nullptr)}
+    {
+        CETL_DEBUG_ASSERT(size_ <= allocated_size_, "");
+        CETL_DEBUG_ASSERT((data_ == nullptr) || (mr_ != nullptr), "");
+        CETL_DEBUG_ASSERT((data_ != nullptr) || ((size_ == 0) && (allocated_size_ == 0)), "");
+    }
+
+    /// @brief Assigns another payload by moving it into this one.
+    ///
+    /// @param other The other payload to move into.
+    ///
+    MediaPayload& operator=(MediaPayload&& other) noexcept
+    {
+        reset();
+
+        size_           = std::exchange(other.size_, 0U);
+        data_           = std::exchange(other.data_, nullptr);
+        allocated_size_ = std::exchange(other.allocated_size_, 0U);
+        mr_             = std::exchange(other.mr_, nullptr);
+
+        return *this;
+    }
+
+    // No copying, but move only!
+    MediaPayload(const MediaPayload& other)            = delete;
+    MediaPayload& operator=(const MediaPayload& other) = delete;
+
+    ~MediaPayload()
+    {
+        reset();
+    }
+
+    /// Gets the constant payload data as a span.
+    ///
+    /// Returns an empty (`{nullptr, 0}`) span if the payload is moved, released or reset.
+    ///
+    cetl::span<const cetl::byte> getSpan() const noexcept
+    {
+        return {data_, size_};
+    }
+
+    /// Gets size (in bytes) of allocated payload buffer.
+    ///
+    /// Returns zero if the payload is moved, released or reset.
+    ///
+    std::size_t getAllocatedSize() const noexcept
+    {
+        return allocated_size_;
+    }
+
+    /// Releases ownership of the payload by returning its data pointer and sizes.
+    ///
+    /// In use to return the payload to the lizard C API when media is not ready yet to accept the payload.
+    /// After this call, corresponding internal fields will be nullified.
+    ///
+    /// @return Tuple with the payload size, pointer to the payload data, and the allocated size.
+    ///         It's the caller's responsibility to deallocate the buffer with the correct memory resource,
+    ///         or move it somewhere else with the same guarantee (like f.e. back to a lizard TX queue item).
+    ///
+    std::tuple<std::size_t, cetl::byte*, std::size_t> release() noexcept
+    {
+        mr_ = nullptr;
+        return std::make_tuple(std::exchange(size_, 0U),
+                               std::exchange(data_, nullptr),
+                               std::exchange(allocated_size_, 0U));
+    }
+
+    /// Resets the payload by de-allocating its data buffer.
+    ///
+    /// Could be called multiple times.
+    ///
+    void reset() noexcept
+    {
+        if (data_ != nullptr)
+        {
+            CETL_DEBUG_ASSERT(mr_ != nullptr, "Memory resource should not be null.");
+
+            // No Sonar `cpp:S5356` b/c we integrate here PMR.
+            mr_->deallocate(data_, allocated_size_);  // NOSONAR cpp:S5356
+
+            mr_             = nullptr;
+            data_           = nullptr;
+            size_           = 0;
+            allocated_size_ = 0;
+        }
+    }
+
+private:
+    /// Size of the payload data in bytes.
+    ///
+    /// Could be less or equal to the allocated size.
+    /// `0` when the payload is moved.
+    ///
+    std::size_t size_{0U};
+
+    /// Pointer to the payload buffer.
+    ///
+    /// `nullptr` when the payload is moved.
+    ///
+    cetl::byte* data_{nullptr};
+
+    /// Size of the allocated buffer.
+    ///
+    /// Could be greater or equal to the payload size.
+    /// `0` when the payload is moved.
+    ///
+    std::size_t allocated_size_{0U};
+
+    /// Holds pointer to the PMR which was used to allocate the payload buffer. Will be used to deallocate it.
+    ///
+    cetl::pmr::memory_resource* mr_{nullptr};
+
+};  // MediaPayload
+
+}  // namespace transport
+}  // namespace libcyphal
+
+#endif  // LIBCYPHAL_TRANSPORT_MEDIA_PAYLOAD_HPP_INCLUDED

--- a/include/libcyphal/transport/media_payload.hpp
+++ b/include/libcyphal/transport/media_payload.hpp
@@ -28,7 +28,13 @@ class MediaPayload final  // NOSONAR : cpp:S4963 - we do directly handle resourc
 public:
     /// Constructs a new empty payload.
     ///
-    MediaPayload() = default;
+    MediaPayload()
+        : size_{0U}
+        , data_{nullptr}
+        , allocated_size_{0U}
+        , mr_{nullptr}
+    {
+    }
 
     /// Constructs a new payload by owning the provided data buffer.
     ///
@@ -152,24 +158,24 @@ private:
     /// Could be less or equal to the allocated size.
     /// `0` when the payload is moved.
     ///
-    std::size_t size_{0U};
+    std::size_t size_;
 
     /// Pointer to the payload buffer.
     ///
     /// `nullptr` when the payload is moved.
     ///
-    cetl::byte* data_{nullptr};
+    cetl::byte* data_;
 
     /// Size of the allocated buffer.
     ///
     /// Could be greater or equal to the payload size.
     /// `0` when the payload is moved.
     ///
-    std::size_t allocated_size_{0U};
+    std::size_t allocated_size_;
 
     /// Holds pointer to the PMR which was used to allocate the payload buffer. Will be used to deallocate it.
     ///
-    cetl::pmr::memory_resource* mr_{nullptr};
+    cetl::pmr::memory_resource* mr_;
 
 };  // MediaPayload
 

--- a/include/libcyphal/transport/udp/delegate.hpp
+++ b/include/libcyphal/transport/udp/delegate.hpp
@@ -203,7 +203,7 @@ public:
     TransportDelegate& operator=(const TransportDelegate&)     = delete;
     TransportDelegate& operator=(TransportDelegate&&) noexcept = delete;
 
-    CETL_NODISCARD const NodeId& node_id() const noexcept
+    CETL_NODISCARD const NodeId& getNodeId() const noexcept
     {
         return udpard_node_id_;
     }
@@ -261,7 +261,7 @@ public:
     /// @param tx_item The TX queue item to be popped and freed.
     /// @param whole_transfer If `true` then whole transfer should be released from the queue.
     ///
-    static void popAndFreeUdpardTxItem(UdpardTx* const tx_queue, const UdpardTxItem* tx_item, const bool whole_transfer)
+    static void popAndFreeUdpardTxItem(UdpardTx* const tx_queue, UdpardTxItem* tx_item, const bool whole_transfer)
     {
         while (UdpardTxItem* const mut_tx_item = ::udpardTxPop(tx_queue, tx_item))
         {
@@ -301,15 +301,15 @@ protected:
         cetl::pmr::memory_resource& general;
 
         /// The session memory resource is used to provide memory for the Udpard session instances.
-        /// Each instance is fixed-size, so a trivial zero-fragmentation block allocator is sufficient.
+        /// Each instance is fixed-size, so a trivial zero-fragmentation block allocator is enough.
         UdpardMemoryResource session;
 
         /// The fragment handles are allocated per payload fragment; each handle contains a pointer to its fragment.
-        /// Each instance is of a very small fixed size, so a trivial zero-fragmentation block allocator is sufficient.
+        /// Each instance is of a very small fixed size, so a trivial zero-fragmentation block allocator is enough.
         UdpardMemoryResource fragment;
 
         /// The library never allocates payload buffers itself, as they are handed over by the application via
-        /// receive calls. Once a buffer is handed over, the library may choose to keep it if it is deemed to be
+        /// reception calls. Once a buffer is handed over, the library may choose to keep it if it is deemed to be
         /// necessary to complete a transfer reassembly, or to discard it if it is deemed to be unnecessary.
         /// Discarded payload buffers are freed using this memory resource.
         UdpardMemoryDeleter payload;

--- a/include/libcyphal/transport/udp/delegate.hpp
+++ b/include/libcyphal/transport/udp/delegate.hpp
@@ -337,7 +337,7 @@ protected:
     {
         // No Sonar `cpp:S5356` b/c the raw `user_reference` is part of libudpard api.
         void* const user_reference = (custom != nullptr) ? custom : &general;  // NOSONAR cpp:S5356
-        return UdpardMemoryResource{user_reference, deallocateMemoryForUdpard, allocateMemoryForUdpard};
+        return {user_reference, deallocateMemoryForUdpard, allocateMemoryForUdpard};
     }
 
     CETL_NODISCARD static UdpardMemoryDeleter makeUdpardMemoryDeleter(cetl::pmr::memory_resource* const custom,
@@ -351,7 +351,7 @@ protected:
 private:
     /// @brief Allocates memory for udpard.
     ///
-    /// NOSONAR cpp:S5008 is unavoidable: this is integration with low-level C code of Udpard memory management.
+    /// NOSONAR cpp:S5008 is unavoidable: this is integration with Udpard C memory management.
     ///
     static void* allocateMemoryForUdpard(void* const user_reference, const size_t size)  // NOSONAR cpp:S5008
     {
@@ -364,7 +364,7 @@ private:
 
     /// @brief Releases memory allocated for udpard (by previous `allocateMemoryForUdpard` call).
     ///
-    /// NOSONAR cpp:S5008 is unavoidable: this is integration with low-level C code of Udpard memory management.
+    /// NOSONAR cpp:S5008 is unavoidable: this is integration with Udpard C memory management.
     ///
     static void deallocateMemoryForUdpard(void* const  user_reference,  // NOSONAR cpp:S5008
                                           const size_t size,

--- a/include/libcyphal/transport/udp/media.hpp
+++ b/include/libcyphal/transport/udp/media.hpp
@@ -99,6 +99,18 @@ public:
     virtual MakeRxSocketResult::Type makeRxSocket(const IpEndpoint& multicast_endpoint) = 0;
     ///@}
 
+    /// Gets the memory resource for the TX frame payload buffers.
+    ///
+    /// The lizard or the client can both allocate and deallocate memory using this memory resource.
+    /// The TX memory resource (MR) will be used to allocate memory for the lizard when it needs to enqueue a new TX
+    /// item. If that item never makes it to the IMedia (for example, if it times out or the transmission is canceled
+    /// for other reasons like running out of queue space or memory), the memory is freed using the same MR. If the item
+    /// actually makes it to IMedia, the `ITxSocket::send` takes ownership of the buffer, so that the client doesn't
+    /// need to free it. What happens to the buffer afterward is none of the client's concerns, the media will take care
+    /// of everything.
+    ///
+    virtual cetl::pmr::memory_resource& getTxMemoryResource() = 0;
+
 protected:
     IMedia()  = default;
     ~IMedia() = default;

--- a/include/libcyphal/transport/udp/svc_tx_sessions.hpp
+++ b/include/libcyphal/transport/udp/svc_tx_sessions.hpp
@@ -85,7 +85,7 @@ private:
         // Otherwise, transport may do some work (like possible payload allocation/copying,
         // media enumeration and pushing into their TX queues) doomed to fail with argument error.
         //
-        if (delegate_.node_id() > UDPARD_NODE_ID_MAX)
+        if (delegate_.getNodeId() > UDPARD_NODE_ID_MAX)
         {
             return ArgumentError{};
         }
@@ -164,7 +164,7 @@ private:
         // Otherwise, transport may do some work (like possible payload allocation/copying,
         // media enumeration and pushing into their TX queues) doomed to fail with argument error.
         //
-        if ((delegate_.node_id() > UDPARD_NODE_ID_MAX) || (metadata.remote_node_id > UDPARD_NODE_ID_MAX))
+        if ((delegate_.getNodeId() > UDPARD_NODE_ID_MAX) || (metadata.remote_node_id > UDPARD_NODE_ID_MAX))
         {
             return ArgumentError{};
         }

--- a/include/libcyphal/transport/udp/udp_transport.hpp
+++ b/include/libcyphal/transport/udp/udp_transport.hpp
@@ -186,17 +186,17 @@ struct MemoryResourcesSpec
     cetl::pmr::memory_resource& general;
 
     /// The session memory resource is used to provide memory for the Udpard session instances.
-    /// Each instance is fixed-size, so a trivial zero-fragmentation block allocator is sufficient.
+    /// Each instance is fixed-size, so a trivial zero-fragmentation block allocator is enough.
     /// If `nullptr` then the `.general` memory resource will be used instead.
     cetl::pmr::memory_resource* session{nullptr};
 
     /// The fragment handles are allocated per payload fragment; each handle contains a pointer to its fragment.
-    /// Each instance is of a very small fixed size, so a trivial zero-fragmentation block allocator is sufficient.
+    /// Each instance is of a very small fixed size, so a trivial zero-fragmentation block allocator is enough.
     /// If `nullptr` then the `.general` memory resource will be used instead.
     cetl::pmr::memory_resource* fragment{nullptr};
 
     /// The library never allocates payload buffers itself, as they are handed over by the application via
-    /// receive calls. Once a buffer is handed over, the library may choose to keep it if it is deemed to be
+    /// reception calls. Once a buffer is handed over, the library may choose to keep it if it is deemed to be
     /// necessary to complete a transfer reassembly, or to discard it if it is deemed to be unnecessary.
     /// Discarded payload buffers are freed using this memory resource.
     /// If `nullptr` then the `.general` memory resource will be used instead.

--- a/include/libcyphal/transport/udp/udp_transport_impl.hpp
+++ b/include/libcyphal/transport/udp/udp_transport_impl.hpp
@@ -122,7 +122,12 @@ class TransportImpl final : private TransportDelegate, public IUdpTransport  // 
         {
             using LizardHelpers = libcyphal::transport::detail::LizardHelpers;
 
-            return LizardHelpers::makeMemoryResource<UdpardMemoryResource>(media_interface.getTxMemoryResource());
+            // TODO: Make it `1` as soon as TX memory resource is used for raw bytes block allocations only.
+            // Currently, it is used for both `UdpardTxItem` and its payload.
+            constexpr std::size_t Alignment = alignof(UdpardTxItem);
+
+            return LizardHelpers::makeMemoryResource<UdpardMemoryResource, Alignment>(
+                media_interface.getTxMemoryResource());
         }
 
         const std::uint8_t     index_;

--- a/include/libcyphal/transport/udp/udp_transport_impl.hpp
+++ b/include/libcyphal/transport/udp/udp_transport_impl.hpp
@@ -73,16 +73,17 @@ class TransportImpl final : private TransportDelegate, public IUdpTransport  // 
     struct Media final
     {
     public:
-        Media(const std::size_t         index,
-              IMedia&                   interface,
-              const UdpardNodeID* const local_node_id,
-              const std::size_t         tx_capacity)
+        Media(const UdpardMemoryResource fragments_mr,
+              const std::size_t          index,
+              IMedia&                    interface,
+              const UdpardNodeID* const  local_node_id,
+              const std::size_t          tx_capacity)
             : index_{static_cast<std::uint8_t>(index)}
             , interface_{interface}
             , udpard_tx_{}
         {
-            const std::int8_t result =
-                ::udpardTxInit(&udpard_tx_, local_node_id, tx_capacity, makeTxMemoryResource(interface));
+            const UdpardTxMemoryResources tx_memory_resources = {fragments_mr, makeTxMemoryResource(interface)};
+            const std::int8_t result = ::udpardTxInit(&udpard_tx_, local_node_id, tx_capacity, tx_memory_resources);
             CETL_DEBUG_ASSERT(result == 0, "There should be no path for an error here.");
             (void) result;
         }
@@ -122,9 +123,9 @@ class TransportImpl final : private TransportDelegate, public IUdpTransport  // 
         {
             using LizardHelpers = libcyphal::transport::detail::LizardHelpers;
 
-            // TODO: Make it `1` as soon as TX memory resource is used for raw bytes block allocations only.
-            // Currently, it is used for both `UdpardTxItem` and its payload.
-            constexpr std::size_t Alignment = alignof(UdpardTxItem);
+            // TX memory resource is used for raw bytes block allocations only.
+            // So it has no alignment requirements.
+            constexpr std::size_t Alignment = 1;
 
             return LizardHelpers::makeMemoryResource<UdpardMemoryResource, Alignment>(
                 media_interface.getTxMemoryResource());
@@ -167,7 +168,7 @@ public:
 
         // False positive of clang-tidy - we move `media_array` to the `transport` instance, so can't make it const.
         // NOLINTNEXTLINE(misc-const-correctness)
-        MediaArray media_array = makeMediaArray(mem_res_spec.general, media_count, media, &unset_node_id, tx_capacity);
+        MediaArray media_array = makeMediaArray(memory_resources, media_count, media, &unset_node_id, tx_capacity);
         if (media_array.size() != media_count)
         {
             return MemoryError{};
@@ -196,7 +197,7 @@ public:
     {
         for (auto& media : media_array_)
         {
-            media.udpard_tx().local_node_id = &node_id();
+            media.udpard_tx().local_node_id = &getNodeId();
         }
     }
 
@@ -232,12 +233,12 @@ private:
 
     CETL_NODISCARD cetl::optional<NodeId> getLocalNodeId() const noexcept override
     {
-        if (node_id() > UDPARD_NODE_ID_MAX)
+        if (getNodeId() > UDPARD_NODE_ID_MAX)
         {
             return cetl::nullopt;
         }
 
-        return cetl::make_optional(node_id());
+        return cetl::make_optional(getNodeId());
     }
 
     CETL_NODISCARD cetl::optional<ArgumentError> setLocalNodeId(const NodeId new_node_id) noexcept override
@@ -249,11 +250,11 @@ private:
 
         // Allow setting the same node ID multiple times, but only once otherwise.
         //
-        if (node_id() == new_node_id)
+        if (getNodeId() == new_node_id)
         {
             return cetl::nullopt;
         }
-        if (node_id() != UDPARD_NODE_ID_UNSET)
+        if (getNodeId() != UDPARD_NODE_ID_UNSET)
         {
             return ArgumentError{};
         }
@@ -595,13 +596,13 @@ private:
         return failure;
     }
 
-    CETL_NODISCARD static MediaArray makeMediaArray(cetl::pmr::memory_resource& memory,
-                                                    const std::size_t           media_count,
-                                                    const cetl::span<IMedia*>   media_interfaces,
-                                                    const UdpardNodeID* const   local_node_id_,
-                                                    const std::size_t           tx_capacity)
+    CETL_NODISCARD static MediaArray makeMediaArray(const MemoryResources&    memory,
+                                                    const std::size_t         media_count,
+                                                    const cetl::span<IMedia*> media_interfaces,
+                                                    const UdpardNodeID* const local_node_id_,
+                                                    const std::size_t         tx_capacity)
     {
-        MediaArray media_array{media_count, &memory};
+        MediaArray media_array{media_count, &memory.general};
 
         // Reserve the space for the whole array (to avoid reallocations).
         // Capacity will be less than requested in case of out of memory.
@@ -614,7 +615,7 @@ private:
                 if (media_interface != nullptr)
                 {
                     IMedia& media = *media_interface;
-                    media_array.emplace_back(index, media, local_node_id_, tx_capacity);
+                    media_array.emplace_back(memory.fragment, index, media, local_node_id_, tx_capacity);
                     index++;
                 }
             }
@@ -670,7 +671,7 @@ private:
 
     static void flushUdpardTxQueue(UdpardTx& udpard_tx)
     {
-        while (const UdpardTxItem* const maybe_item = ::udpardTxPeek(&udpard_tx))
+        while (UdpardTxItem* const maybe_item = ::udpardTxPeek(&udpard_tx))
         {
             UdpardTxItem* const item = ::udpardTxPop(&udpard_tx, maybe_item);
             ::udpardTxFree(udpard_tx.memory, item);
@@ -684,7 +685,7 @@ private:
         using PayloadFragment = cetl::span<const cetl::byte>;
 
         TimePoint tx_deadline;
-        while (const UdpardTxItem* const tx_item = peekFirstValidTxItem(media.udpard_tx(), tx_deadline))
+        while (UdpardTxItem* const tx_item = peekFirstValidTxItem(media.udpard_tx(), tx_deadline))
         {
             // No Sonar `cpp:S5356` and `cpp:S5357` b/c we integrate here with C libudpard API.
             const auto* const buffer =
@@ -746,11 +747,11 @@ private:
     /// While searching, any of already expired TX items are pop from the queue and freed (aka dropped).
     /// If there is no still valid TX items in the queue, returns `nullptr`.
     ///
-    CETL_NODISCARD const UdpardTxItem* peekFirstValidTxItem(UdpardTx& udpard_tx, TimePoint& out_deadline) const
+    CETL_NODISCARD UdpardTxItem* peekFirstValidTxItem(UdpardTx& udpard_tx, TimePoint& out_deadline) const
     {
         const TimePoint now = executor_.now();
 
-        while (const UdpardTxItem* const tx_item = ::udpardTxPeek(&udpard_tx))
+        while (UdpardTxItem* const tx_item = ::udpardTxPeek(&udpard_tx))
         {
             // We are dropping any TX item that has expired.
             // Otherwise, we would send it to the media TX socket interface.

--- a/test/unittest/presentation/test_presentation.cpp
+++ b/test/unittest/presentation/test_presentation.cpp
@@ -703,8 +703,7 @@ TEST_F(TestPresentation, makeClient_raw)
 
     Presentation presentation{mr_, scheduler_, transport_mock_};
 
-    auto maybe_client =
-        presentation.makeClient(rx_params.server_node_id, rx_params.service_id, rx_params.extent_bytes);
+    auto maybe_client = presentation.makeClient(rx_params.server_node_id, rx_params.service_id, rx_params.extent_bytes);
     ASSERT_THAT(maybe_client, VariantWith<RawServiceClient>(_));
 
     EXPECT_CALL(req_tx_session_mock, deinit()).Times(1);

--- a/test/unittest/sonar.cpp
+++ b/test/unittest/sonar.cpp
@@ -41,6 +41,7 @@
 #include <libcyphal/transport/contiguous_payload.hpp>
 #include <libcyphal/transport/errors.hpp>
 #include <libcyphal/transport/lizard_helpers.hpp>
+#include <libcyphal/transport/media_payload.hpp>
 #include <libcyphal/transport/msg_sessions.hpp>
 #include <libcyphal/transport/scattered_buffer.hpp>
 #include <libcyphal/transport/session.hpp>

--- a/test/unittest/sonar.cpp
+++ b/test/unittest/sonar.cpp
@@ -40,6 +40,7 @@
 #include <libcyphal/transport/can/svc_tx_sessions.hpp>
 #include <libcyphal/transport/contiguous_payload.hpp>
 #include <libcyphal/transport/errors.hpp>
+#include <libcyphal/transport/lizard_helpers.hpp>
 #include <libcyphal/transport/msg_sessions.hpp>
 #include <libcyphal/transport/scattered_buffer.hpp>
 #include <libcyphal/transport/session.hpp>

--- a/test/unittest/tracking_memory_resource.hpp
+++ b/test/unittest/tracking_memory_resource.hpp
@@ -73,6 +73,7 @@ private:
             CETL_DEBUG_ASSERT(prev_alloc != allocations.cend(), "");
             if (prev_alloc != allocations.cend())
             {
+                CETL_DEBUG_ASSERT(prev_alloc->size == size_bytes, "");
                 allocations.erase(prev_alloc);
             }
             total_deallocated_bytes += size_bytes;
@@ -100,6 +101,7 @@ private:
             CETL_DEBUG_ASSERT(prev_alloc != allocations.cend(), "");
             if (prev_alloc != allocations.cend())
             {
+                CETL_DEBUG_ASSERT(prev_alloc->size == old_size_bytes, "");
                 allocations.erase(prev_alloc);
             }
             total_allocated_bytes -= old_size_bytes;

--- a/test/unittest/transport/can/media_mock.hpp
+++ b/test/unittest/transport/can/media_mock.hpp
@@ -42,7 +42,7 @@ public:
 
     MOCK_METHOD(PushResult::Type,
                 push,
-                (const TimePoint deadline, const CanId can_id, const cetl::span<const cetl::byte> payload),
+                (const TimePoint deadline, const CanId can_id, MediaPayload& payload),
                 (noexcept, override));
 
     MOCK_METHOD(PopResult::Type, pop, (const cetl::span<cetl::byte> payload_buffer), (noexcept, override));

--- a/test/unittest/transport/can/media_mock.hpp
+++ b/test/unittest/transport/can/media_mock.hpp
@@ -57,6 +57,8 @@ public:
                 (IExecutor::Callback::Function && function),
                 (override));
 
+    MOCK_METHOD(cetl::pmr::memory_resource&, getTxMemoryResource, (), (override));
+
 };  // MediaMock
 
 }  // namespace can

--- a/test/unittest/transport/can/test_can_delegate.cpp
+++ b/test/unittest/transport/can/test_can_delegate.cpp
@@ -96,7 +96,7 @@ TEST_F(TestCanDelegate, CanardMemory_copy)
     using CanardMemory = detail::TransportDelegate::CanardMemory;
 
     TransportDelegateImpl delegate{mr_};
-    auto&                 canard_instance = delegate.canard_instance();
+    auto&                 canard_instance = delegate.canardInstance();
 
     const std::size_t payload_size   = 4;
     const std::size_t allocated_size = payload_size + 1;
@@ -156,7 +156,7 @@ TEST_F(TestCanDelegate, CanardMemory_copy_on_moved)
     using CanardMemory = can::detail::TransportDelegate::CanardMemory;
 
     TransportDelegateImpl delegate{mr_};
-    auto&                 canard_instance = delegate.canard_instance();
+    auto&                 canard_instance = delegate.canardInstance();
 
     constexpr std::size_t payload_size = 4;
     auto* const           payload      = static_cast<byte*>(
@@ -205,7 +205,7 @@ TEST_F(TestCanDelegate, canardMemoryAllocate_no_memory)
     StrictMock<MemoryResourceMock> mr_mock;
 
     TransportDelegateImpl delegate{mr_mock};
-    auto&                 canard_instance = delegate.canard_instance();
+    auto&                 canard_instance = delegate.canardInstance();
 
     // Emulate that there is no memory at all.
     EXPECT_CALL(mr_mock, do_allocate(_, _))  //

--- a/test/unittest/transport/can/test_can_msg_rx_session.cpp
+++ b/test/unittest/transport/can/test_can_msg_rx_session.cpp
@@ -51,6 +51,7 @@ using testing::SizeIs;
 using testing::IsEmpty;
 using testing::NotNull;
 using testing::Optional;
+using testing::ReturnRef;
 using testing::StrictMock;
 using testing::ElementsAre;
 using testing::VariantWith;
@@ -72,12 +73,16 @@ protected:
 
         EXPECT_CALL(media_mock_, getMtu())  //
             .WillRepeatedly(Return(CANARD_MTU_MAX));
+        EXPECT_CALL(media_mock_, getTxMemoryResource()).WillRepeatedly(ReturnRef(tx_mr_));
     }
 
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
+
+        EXPECT_THAT(tx_mr_.allocations, IsEmpty());
+        EXPECT_THAT(tx_mr_.total_allocated_bytes, tx_mr_.total_deallocated_bytes);
     }
 
     TimePoint now() const
@@ -99,6 +104,7 @@ protected:
     // NOLINTBEGIN
     libcyphal::VirtualTimeScheduler scheduler_{};
     TrackingMemoryResource          mr_;
+    TrackingMemoryResource          tx_mr_;
     StrictMock<MediaMock>           media_mock_{};
     // NOLINTEND
 };

--- a/test/unittest/transport/can/test_can_msg_rx_session.cpp
+++ b/test/unittest/transport/can/test_can_msg_rx_session.cpp
@@ -129,7 +129,7 @@ TEST_F(TestCanMsgRxSession, make_setTransferIdTimeout)
 
     // NOLINTNEXTLINE
     auto&                 delegate        = static_cast<can::detail::TransportImpl*>(transport.get())->asDelegate();
-    auto&                 canard_instance = delegate.canard_instance();
+    auto&                 canard_instance = delegate.canardInstance();
     CanardRxSubscription* subscription    = nullptr;
     EXPECT_THAT(canardRxGetSubscription(&canard_instance, CanardTransferKindMessage, 123, &subscription), 1);
     ASSERT_THAT(subscription, NotNull());

--- a/test/unittest/transport/can/test_can_msg_tx_session.cpp
+++ b/test/unittest/transport/can/test_can_msg_tx_session.cpp
@@ -51,6 +51,7 @@ using testing::Return;
 using testing::IsEmpty;
 using testing::NotNull;
 using testing::Optional;
+using testing::ReturnRef;
 using testing::StrictMock;
 using testing::ElementsAre;
 using testing::VariantWith;
@@ -75,12 +76,16 @@ protected:
             .WillRepeatedly(Return(CANARD_MTU_CAN_CLASSIC));
         EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
             .WillOnce(Return(cetl::nullopt));
+        EXPECT_CALL(media_mock_, getTxMemoryResource()).WillRepeatedly(ReturnRef(tx_mr_));
     }
 
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
+
+        EXPECT_THAT(tx_mr_.allocations, IsEmpty());
+        EXPECT_THAT(tx_mr_.total_allocated_bytes, tx_mr_.total_deallocated_bytes);
     }
 
     TimePoint now() const
@@ -102,6 +107,7 @@ protected:
     // NOLINTBEGIN
     libcyphal::VirtualTimeScheduler scheduler_{};
     TrackingMemoryResource          mr_;
+    TrackingMemoryResource          tx_mr_;
     StrictMock<MediaMock>           media_mock_{};
     // NOLINTEND
 };

--- a/test/unittest/transport/can/test_can_msg_tx_session.cpp
+++ b/test/unittest/transport/can/test_can_msg_tx_session.cpp
@@ -179,14 +179,14 @@ TEST_F(TestCanMsgTxSession, send_empty_payload)
         // Emulate that media has not accepted the payload.
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto payload) {
+            .WillOnce([&](auto deadline, auto can_id, auto& payload) {
                 EXPECT_THAT(now(), metadata.deadline - timeout);
                 EXPECT_THAT(deadline, metadata.deadline);
                 EXPECT_THAT(can_id, SubjectOfCanIdEq(123));
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
                 auto tbm = TailByteEq(metadata.base.transfer_id);
-                EXPECT_THAT(payload, ElementsAre(tbm));
+                EXPECT_THAT(payload.getSpan(), ElementsAre(tbm));
                 return IMedia::PushResult::Success{false /* is_accepted */};
             });
         EXPECT_CALL(media_mock_, registerPushCallback(_))  //
@@ -263,13 +263,13 @@ TEST_F(TestCanMsgTxSession, send_7bytes_payload_with_500ms_timeout)
     scheduler_.scheduleAt(1s + timeout - 1us, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto, auto can_id, auto pld) {
+            .WillOnce([&](auto, auto can_id, auto& pld) {
                 EXPECT_THAT(now(), metadata.deadline - 1us);
                 EXPECT_THAT(can_id, SubjectOfCanIdEq(17));
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
                 auto tbm = TailByteEq(metadata.base.transfer_id);
-                EXPECT_THAT(pld, ElementsAre(b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), b('7'), tbm));
+                EXPECT_THAT(pld.getSpan(), ElementsAre(b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), b('7'), tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
     });

--- a/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
@@ -60,6 +60,7 @@ using testing::SizeIs;
 using testing::IsEmpty;
 using testing::NotNull;
 using testing::Optional;
+using testing::ReturnRef;
 using testing::StrictMock;
 using testing::ElementsAre;
 using testing::VariantWith;
@@ -82,12 +83,16 @@ protected:
 
         EXPECT_CALL(media_mock_, getMtu())  //
             .WillRepeatedly(Return(CANARD_MTU_CAN_CLASSIC));
+        EXPECT_CALL(media_mock_, getTxMemoryResource()).WillRepeatedly(ReturnRef(tx_mr_));
     }
 
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
+
+        EXPECT_THAT(tx_mr_.allocations, IsEmpty());
+        EXPECT_THAT(tx_mr_.total_allocated_bytes, tx_mr_.total_deallocated_bytes);
     }
 
     TimePoint now() const
@@ -138,6 +143,7 @@ protected:
     // NOLINTBEGIN
     libcyphal::VirtualTimeScheduler scheduler_{};
     TrackingMemoryResource          mr_;
+    TrackingMemoryResource          tx_mr_;
     StrictMock<MediaMock>           media_mock_{};
     // NOLINTEND
 };
@@ -559,6 +565,7 @@ TEST_F(TestCanSvcRxSessions, receive_multiple_tids_frames)
 {
     StrictMock<MediaMock> media_mock2{};
     EXPECT_CALL(media_mock2, getMtu()).WillRepeatedly(Return(CANARD_MTU_CAN_CLASSIC));
+    EXPECT_CALL(media_mock2, getTxMemoryResource()).WillRepeatedly(ReturnRef(tx_mr_));
 
     auto transport = makeTransport(mr_, 42, &media_mock2);
 

--- a/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
@@ -168,7 +168,7 @@ TEST_F(TestCanSvcRxSessions, make_request_setTransferIdTimeout)
 
     // NOLINTNEXTLINE
     auto&                 delegate        = static_cast<can::detail::TransportImpl*>(transport.get())->asDelegate();
-    auto&                 canard_instance = delegate.canard_instance();
+    auto&                 canard_instance = delegate.canardInstance();
     CanardRxSubscription* subscription    = nullptr;
     EXPECT_THAT(canardRxGetSubscription(&canard_instance, CanardTransferKindRequest, 123, &subscription), 1);
     ASSERT_THAT(subscription, NotNull());

--- a/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
@@ -183,7 +183,7 @@ TEST_F(TestCanSvcTxSessions, send_request)
     scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto payload) {
+            .WillOnce([&](auto deadline, auto can_id, auto& payload) {
                 EXPECT_THAT(now(), metadata.deadline - timeout);
                 EXPECT_THAT(deadline, metadata.deadline);
                 EXPECT_THAT(can_id, ServiceOfCanIdEq(123));
@@ -191,7 +191,7 @@ TEST_F(TestCanSvcTxSessions, send_request)
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsServiceCanId()));
 
                 auto tbm = TailByteEq(metadata.base.transfer_id);
-                EXPECT_THAT(payload, ElementsAre(tbm));
+                EXPECT_THAT(payload.getSpan(), ElementsAre(tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
         EXPECT_CALL(media_mock_, registerPushCallback(_))  //
@@ -235,7 +235,7 @@ TEST_F(TestCanSvcTxSessions, send_request_with_argument_error)
         EXPECT_THAT(transport->setLocalNodeId(13), Eq(cetl::nullopt));
 
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto payload) {
+            .WillOnce([&](auto deadline, auto can_id, auto& payload) {
                 EXPECT_THAT(now(), metadata.deadline - timeout);
                 EXPECT_THAT(deadline, metadata.deadline);
                 EXPECT_THAT(can_id, ServiceOfCanIdEq(123));
@@ -243,7 +243,7 @@ TEST_F(TestCanSvcTxSessions, send_request_with_argument_error)
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsServiceCanId()));
 
                 auto tbm = TailByteEq(metadata.base.transfer_id);
-                EXPECT_THAT(payload, ElementsAre(tbm));
+                EXPECT_THAT(payload.getSpan(), ElementsAre(tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
         EXPECT_CALL(media_mock_, registerPushCallback(_))  //
@@ -319,7 +319,7 @@ TEST_F(TestCanSvcTxSessions, send_response)
     scheduler_.scheduleAt(1s, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto payload) {
+            .WillOnce([&](auto deadline, auto can_id, auto& payload) {
                 EXPECT_THAT(now(), metadata.tx_meta.deadline - timeout);
                 EXPECT_THAT(deadline, metadata.tx_meta.deadline);
                 EXPECT_THAT(can_id, ServiceOfCanIdEq(123));
@@ -327,7 +327,7 @@ TEST_F(TestCanSvcTxSessions, send_response)
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.tx_meta.base.priority), IsServiceCanId()));
 
                 auto tbm = TailByteEq(metadata.tx_meta.base.transfer_id);
-                EXPECT_THAT(payload, ElementsAre(tbm));
+                EXPECT_THAT(payload.getSpan(), ElementsAre(tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
         EXPECT_CALL(media_mock_, registerPushCallback(_))  //

--- a/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_tx_sessions.cpp
@@ -47,6 +47,7 @@ using testing::Return;
 using testing::IsEmpty;
 using testing::NotNull;
 using testing::Optional;
+using testing::ReturnRef;
 using testing::StrictMock;
 using testing::ElementsAre;
 using testing::VariantWith;
@@ -70,12 +71,16 @@ protected:
             .WillRepeatedly(Return(CANARD_MTU_CAN_CLASSIC));
         EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
             .WillOnce(Return(cetl::nullopt));
+        EXPECT_CALL(media_mock_, getTxMemoryResource()).WillRepeatedly(ReturnRef(tx_mr_));
     }
 
     void TearDown() override
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
+
+        EXPECT_THAT(tx_mr_.allocations, IsEmpty());
+        EXPECT_THAT(tx_mr_.total_allocated_bytes, tx_mr_.total_deallocated_bytes);
     }
 
     TimePoint now() const
@@ -101,6 +106,7 @@ protected:
     // NOLINTBEGIN
     libcyphal::VirtualTimeScheduler scheduler_{};
     TrackingMemoryResource          mr_;
+    TrackingMemoryResource          tx_mr_;
     StrictMock<MediaMock>           media_mock_{};
     // NOLINTEND
 };

--- a/test/unittest/transport/can/test_can_transport.cpp
+++ b/test/unittest/transport/can/test_can_transport.cpp
@@ -533,14 +533,14 @@ TEST_F(TestCanTransport, sending_multiframe_payload_for_non_anonymous)
 
     scheduler_.scheduleAt(1s, [&](const auto&) {
         //
-        EXPECT_CALL(media_mock_, push(_, _, _)).WillOnce([&](auto deadline, auto can_id, auto pld) {
+        EXPECT_CALL(media_mock_, push(_, _, _)).WillOnce([&](auto deadline, auto can_id, auto& pld) {
             EXPECT_THAT(now(), metadata.deadline - timeout);
             EXPECT_THAT(deadline, metadata.deadline);
             EXPECT_THAT(can_id, AllOf(SubjectOfCanIdEq(7), SourceNodeOfCanIdEq(0x45)));
             EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
             const auto tbm = TailByteEq(metadata.base.transfer_id, true, false);
-            EXPECT_THAT(pld, ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
+            EXPECT_THAT(pld.getSpan(), ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
             return IMedia::PushResult::Success{true /* is_accepted */};
         });
         EXPECT_CALL(media_mock_, registerPushCallback(_))  //
@@ -554,14 +554,14 @@ TEST_F(TestCanTransport, sending_multiframe_payload_for_non_anonymous)
     });
     scheduler_.scheduleAt(1s + 10us, [&](const auto&) {
         //
-        EXPECT_CALL(media_mock_, push(_, _, _)).WillOnce([&](auto deadline, auto can_id, auto pld) {
+        EXPECT_CALL(media_mock_, push(_, _, _)).WillOnce([&](auto deadline, auto can_id, auto& pld) {
             EXPECT_THAT(now(), metadata.deadline - timeout + 10us);
             EXPECT_THAT(deadline, metadata.deadline);
             EXPECT_THAT(can_id, AllOf(SubjectOfCanIdEq(7), SourceNodeOfCanIdEq(0x45)));
             EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
             const auto tbm = TailByteEq(metadata.base.transfer_id, false, true, false);
-            EXPECT_THAT(pld, ElementsAre(b('7'), _, _ /* CRC bytes */, tbm));
+            EXPECT_THAT(pld.getSpan(), ElementsAre(b('7'), _, _ /* CRC bytes */, tbm));
             return IMedia::PushResult::Success{true /* is_accepted */};
         });
     });
@@ -598,7 +598,7 @@ TEST_F(TestCanTransport, send_multiframe_payload_to_redundant_not_ready_media)
         // the second media, and will retry with the 1st only when its socket is ready @ +20us.
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto, auto, auto) {
+            .WillOnce([&](auto, auto, auto&) {
                 EXPECT_THAT(now(), metadata.deadline - timeout);
                 return IMedia::PushResult::Success{false /* is_accepted */};
             });
@@ -607,14 +607,14 @@ TEST_F(TestCanTransport, send_multiframe_payload_to_redundant_not_ready_media)
                 return scheduler_.registerAndScheduleNamedCallback("tx1", now() + 20us, std::move(function));
             }));
         EXPECT_CALL(media_mock2, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto pld) {
+            .WillOnce([&](auto deadline, auto can_id, auto& pld) {
                 EXPECT_THAT(now(), metadata.deadline - timeout);
                 EXPECT_THAT(deadline, metadata.deadline);
                 EXPECT_THAT(can_id, AllOf(SubjectOfCanIdEq(7), SourceNodeOfCanIdEq(0x45)));
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
                 auto tbm = TailByteEq(metadata.base.transfer_id, true, false);
-                EXPECT_THAT(pld, ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
+                EXPECT_THAT(pld.getSpan(), ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
         EXPECT_CALL(media_mock2, registerPushCallback(_))  //
@@ -629,28 +629,28 @@ TEST_F(TestCanTransport, send_multiframe_payload_to_redundant_not_ready_media)
     scheduler_.scheduleAt(1s + 10us, [&](const auto&) {
         //
         EXPECT_CALL(media_mock2, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto pld) {
+            .WillOnce([&](auto deadline, auto can_id, auto& pld) {
                 EXPECT_THAT(now(), metadata.deadline - timeout + 10us);
                 EXPECT_THAT(deadline, metadata.deadline);
                 EXPECT_THAT(can_id, AllOf(SubjectOfCanIdEq(7), SourceNodeOfCanIdEq(0x45)));
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
                 const auto tbm = TailByteEq(metadata.base.transfer_id, false, true, false);
-                EXPECT_THAT(pld, ElementsAre(b('7'), b('8'), b('9'), b(0x7D), b(0x61) /* CRC bytes */, tbm));
+                EXPECT_THAT(pld.getSpan(), ElementsAre(b('7'), b('8'), b('9'), b(0x7D), b(0x61) /* CRC bytes */, tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
     });
     scheduler_.scheduleAt(1s + 20us, [&](const auto&) {
         //
         EXPECT_CALL(media_mock_, push(_, _, _))  //
-            .WillOnce([&](auto deadline, auto can_id, auto pld) {
+            .WillOnce([&](auto deadline, auto can_id, auto& pld) {
                 EXPECT_THAT(now(), metadata.deadline - timeout + 20us);
                 EXPECT_THAT(deadline, metadata.deadline);
                 EXPECT_THAT(can_id, AllOf(SubjectOfCanIdEq(7), SourceNodeOfCanIdEq(0x45)));
                 EXPECT_THAT(can_id, AllOf(PriorityOfCanIdEq(metadata.base.priority), IsMessageCanId()));
 
                 const auto tbm = TailByteEq(metadata.base.transfer_id, true, false);
-                EXPECT_THAT(pld, ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
+                EXPECT_THAT(pld.getSpan(), ElementsAre(b('0'), b('1'), b('2'), b('3'), b('4'), b('5'), b('6'), tbm));
                 return IMedia::PushResult::Success{true /* is_accepted */};
             });
     });

--- a/test/unittest/transport/test_media_payload.cpp
+++ b/test/unittest/transport/test_media_payload.cpp
@@ -1,0 +1,145 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#include "tracking_memory_resource.hpp"
+
+#include <cetl/pf17/cetlpf.hpp>
+#include <libcyphal/transport/media_payload.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <utility>
+
+namespace
+{
+
+using namespace libcyphal::transport;  // NOLINT This our main concern here in the unit tests.
+
+using testing::IsEmpty;
+
+class TestMediaPayload : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        cetl::pmr::set_default_resource(&mr_);
+    }
+
+    void TearDown() override
+    {
+        EXPECT_THAT(mr_.allocations, IsEmpty());
+        EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
+    }
+
+    // MARK: Data members:
+
+    // NOLINTBEGIN
+    TrackingMemoryResource mr_;
+    // NOLINTEND
+};
+
+// MARK: - Tests:
+
+TEST_F(TestMediaPayload, default_ctor)
+{
+    MediaPayload payload;
+    EXPECT_THAT(payload.getSpan().size(), 0);
+    EXPECT_THAT(payload.getSpan().data(), nullptr);
+    EXPECT_THAT(payload.getAllocatedSize(), 0);
+
+    // It's fine to attempt to reset or release an empty payload.
+    const auto fields = payload.release();
+    EXPECT_THAT(std::get<0>(fields), 0);
+    EXPECT_THAT(std::get<1>(fields), nullptr);
+    EXPECT_THAT(std::get<2>(fields), 0);
+
+    payload.reset();
+}
+
+TEST_F(TestMediaPayload, main_ctor)
+{
+    constexpr std::size_t payload_size           = 5;
+    constexpr std::size_t payload_allocated_size = 8;
+    auto* const           payload_data           = static_cast<cetl::byte*>(mr_.allocate(payload_allocated_size));
+
+    const MediaPayload payload{payload_size, payload_data, payload_allocated_size, &mr_};
+    EXPECT_THAT(payload.getSpan().size(), payload_size);
+    EXPECT_THAT(payload.getSpan().data(), payload_data);
+    EXPECT_THAT(payload.getAllocatedSize(), payload_allocated_size);
+}
+
+TEST_F(TestMediaPayload, move_ctor)
+{
+    constexpr std::size_t payload_size           = 5;
+    constexpr std::size_t payload_allocated_size = 8;
+    auto* const           payload_data           = static_cast<cetl::byte*>(mr_.allocate(payload_allocated_size));
+
+    MediaPayload payload1{payload_size, payload_data, payload_allocated_size, &mr_};
+
+    const MediaPayload payload2{std::move(payload1)};
+
+    EXPECT_THAT(payload2.getSpan().size(), payload_size);
+    EXPECT_THAT(payload2.getSpan().data(), payload_data);
+    EXPECT_THAT(payload2.getAllocatedSize(), payload_allocated_size);
+}
+
+TEST_F(TestMediaPayload, move_assignment)
+{
+    constexpr std::size_t payload_size           = 5;
+    constexpr std::size_t payload_allocated_size = 8;
+    auto* const           payload_data           = static_cast<cetl::byte*>(mr_.allocate(payload_allocated_size));
+
+    MediaPayload payload1{payload_size, payload_data, payload_allocated_size, &mr_};
+
+    MediaPayload payload2{};
+    payload2 = std::move(payload1);
+
+    EXPECT_THAT(payload2.getSpan().size(), payload_size);
+    EXPECT_THAT(payload2.getSpan().data(), payload_data);
+    EXPECT_THAT(payload2.getAllocatedSize(), payload_allocated_size);
+}
+
+TEST_F(TestMediaPayload, release)
+{
+    constexpr std::size_t payload_size           = 5;
+    constexpr std::size_t payload_allocated_size = 8;
+    auto* const           payload_data           = static_cast<cetl::byte*>(mr_.allocate(payload_allocated_size));
+
+    MediaPayload payload{payload_size, payload_data, payload_allocated_size, &mr_};
+
+    auto fields = payload.release();
+    EXPECT_THAT(std::get<0>(fields), payload_size);
+    EXPECT_THAT(std::get<1>(fields), payload_data);
+    EXPECT_THAT(std::get<2>(fields), payload_allocated_size);
+    mr_.deallocate(std::get<1>(fields), std::get<2>(fields));
+
+    fields = payload.release();
+    EXPECT_THAT(std::get<0>(fields), 0);
+    EXPECT_THAT(std::get<1>(fields), nullptr);
+    EXPECT_THAT(std::get<2>(fields), 0);
+}
+
+TEST_F(TestMediaPayload, reset)
+{
+    constexpr std::size_t payload_size           = 5;
+    constexpr std::size_t payload_allocated_size = 8;
+    auto* const           payload_data           = static_cast<cetl::byte*>(mr_.allocate(payload_allocated_size));
+
+    MediaPayload payload{payload_size, payload_data, payload_allocated_size, &mr_};
+
+    payload.reset();
+    EXPECT_THAT(payload.getSpan().size(), 0);
+    EXPECT_THAT(payload.getSpan().data(), nullptr);
+    EXPECT_THAT(payload.getAllocatedSize(), 0);
+
+    payload.reset();
+    EXPECT_THAT(payload.getSpan().size(), 0);
+    EXPECT_THAT(payload.getSpan().data(), nullptr);
+    EXPECT_THAT(payload.getAllocatedSize(), 0);
+}
+
+}  // namespace

--- a/test/unittest/transport/udp/media_mock.hpp
+++ b/test/unittest/transport/udp/media_mock.hpp
@@ -35,6 +35,7 @@ public:
 
     MOCK_METHOD(MakeTxSocketResult::Type, makeTxSocket, (), (override));
     MOCK_METHOD(MakeRxSocketResult::Type, makeRxSocket, (const IpEndpoint& multicast_endpoint), (override));
+    MOCK_METHOD(cetl::pmr::memory_resource&, getTxMemoryResource, (), (override));
 
 };  // MediaMock
 

--- a/test/unittest/transport/udp/test_udp_delegate.cpp
+++ b/test/unittest/transport/udp/test_udp_delegate.cpp
@@ -91,13 +91,13 @@ protected:
     void TearDown() override
     {
         EXPECT_THAT(general_mr_.allocations, IsEmpty());
-        EXPECT_EQ(general_mr_.total_allocated_bytes, general_mr_.total_deallocated_bytes);
+        EXPECT_THAT(general_mr_.total_allocated_bytes, general_mr_.total_deallocated_bytes);
 
         EXPECT_THAT(fragment_mr_.allocations, IsEmpty());
-        EXPECT_EQ(fragment_mr_.total_allocated_bytes, fragment_mr_.total_deallocated_bytes);
+        EXPECT_THAT(fragment_mr_.total_allocated_bytes, fragment_mr_.total_deallocated_bytes);
 
         EXPECT_THAT(payload_mr_.allocations, IsEmpty());
-        EXPECT_EQ(payload_mr_.total_allocated_bytes, payload_mr_.total_deallocated_bytes);
+        EXPECT_THAT(payload_mr_.total_allocated_bytes, payload_mr_.total_deallocated_bytes);
     }
 
     byte* allocateNewUdpardPayload(const std::size_t size)
@@ -109,7 +109,7 @@ protected:
     {
         // This structure mimics internal Udpard `RxFragment` layout.
         // We need this to know its size, so that test tear down can check if all memory was deallocated.
-        // @see `EXPECT_EQ(fragment_mr_.total_allocated_bytes, fragment_mr_.total_deallocated_bytes);`
+        // @see `EXPECT_THAT(fragment_mr_.total_allocated_bytes, fragment_mr_.total_deallocated_bytes);`
         //
         struct RxFragment
         {

--- a/test/unittest/transport/udp/test_udp_msg_tx_session.cpp
+++ b/test/unittest/transport/udp/test_udp_msg_tx_session.cpp
@@ -57,6 +57,7 @@ using testing::Return;
 using testing::SizeIs;
 using testing::IsEmpty;
 using testing::NotNull;
+using testing::ReturnRef;
 using testing::StrictMock;
 using testing::VariantWith;
 
@@ -80,6 +81,8 @@ protected:
             .WillRepeatedly(Invoke([this] {
                 return libcyphal::detail::makeUniquePtr<TxSocketMock::RefWrapper::Spec>(mr_, tx_socket_mock_);
             }));
+        EXPECT_CALL(media_mock_, getTxMemoryResource()).WillRepeatedly(ReturnRef(tx_mr_));
+
         EXPECT_CALL(tx_socket_mock_, getMtu())  //
             .WillRepeatedly(Return(UDPARD_MTU_DEFAULT));
     }
@@ -88,6 +91,9 @@ protected:
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
+
+        EXPECT_THAT(tx_mr_.allocations, IsEmpty());
+        EXPECT_THAT(tx_mr_.total_allocated_bytes, tx_mr_.total_deallocated_bytes);
     }
 
     TimePoint now() const
@@ -109,6 +115,7 @@ protected:
     // NOLINTBEGIN
     libcyphal::VirtualTimeScheduler scheduler_{};
     TrackingMemoryResource          mr_;
+    TrackingMemoryResource          tx_mr_;
     StrictMock<MediaMock>           media_mock_{};
     StrictMock<TxSocketMock>        tx_socket_mock_{"S1"};
     // NOLINTEND
@@ -231,10 +238,11 @@ TEST_F(TestUdpMsgTxSession, make_fails_due_to_media_socket)
 
 TEST_F(TestUdpMsgTxSession, send_empty_payload)
 {
-    StrictMock<MemoryResourceMock> fragment_mr_mock;
-    fragment_mr_mock.redirectExpectedCallsTo(mr_);
+    StrictMock<MemoryResourceMock> tx_mr_mock;
+    tx_mr_mock.redirectExpectedCallsTo(tx_mr_);
+    EXPECT_CALL(media_mock_, getTxMemoryResource()).WillRepeatedly(ReturnRef(tx_mr_mock));
 
-    auto transport = makeTransport({mr_, nullptr, &fragment_mr_mock});
+    auto transport = makeTransport({mr_});
 
     auto maybe_session = transport->makeMessageTxSession({123});
     ASSERT_THAT(maybe_session, VariantWith<UniquePtr<IMessageTxSession>>(NotNull()));
@@ -245,15 +253,15 @@ TEST_F(TestUdpMsgTxSession, send_empty_payload)
 
     scheduler_.scheduleAt(1s, [&](const auto&) {
         //
-        // TX item for our payload to send is expected to be de/allocated on the *fragment* memory resource.
+        // TX item for our payload to send is expected to be de/allocated on the media TX memory resource.
         //
-        EXPECT_CALL(fragment_mr_mock, do_allocate(_, _))
-            .WillOnce([&](std::size_t size_bytes, std::size_t alignment) -> void* {
-                return mr_.allocate(size_bytes, alignment);
+        EXPECT_CALL(tx_mr_mock, do_allocate(_, _))
+            .WillOnce([&](const std::size_t size_bytes, const std::size_t alignment) -> void* {
+                return tx_mr_.allocate(size_bytes, alignment);
             });
-        EXPECT_CALL(fragment_mr_mock, do_deallocate(_, _, _))
-            .WillOnce([&](void* p, std::size_t size_bytes, std::size_t alignment) {
-                mr_.deallocate(p, size_bytes, alignment);
+        EXPECT_CALL(tx_mr_mock, do_deallocate(_, _, _))
+            .WillOnce([&](void* const p, const std::size_t size_bytes, const std::size_t alignment) {
+                tx_mr_.deallocate(p, size_bytes, alignment);
             });
 
         // Emulate that TX socket has not accepted the payload.

--- a/test/unittest/transport/udp/test_udp_transport.cpp
+++ b/test/unittest/transport/udp/test_udp_transport.cpp
@@ -59,6 +59,7 @@ using testing::SizeIs;
 using testing::IsEmpty;
 using testing::NotNull;
 using testing::Optional;
+using testing::ReturnRef;
 using testing::StrictMock;
 using testing::VariantWith;
 
@@ -112,6 +113,7 @@ protected:
                 rx_socket_mock_.setEndpoint(endpoint);
                 return libcyphal::detail::makeUniquePtr<RxSocketMock::RefWrapper::Spec>(mr_, rx_socket_mock_);
             }));
+        EXPECT_CALL(media_mock_, getTxMemoryResource()).WillRepeatedly(ReturnRef(mr_));
 
         EXPECT_CALL(tx_socket_mock_, getMtu()).WillRepeatedly(Invoke(&tx_socket_mock_, &TxSocketMock::getBaseMtu));
     }
@@ -120,6 +122,9 @@ protected:
     {
         EXPECT_THAT(mr_.allocations, IsEmpty());
         EXPECT_THAT(mr_.total_allocated_bytes, mr_.total_deallocated_bytes);
+
+        EXPECT_THAT(tx_mr_.allocations, IsEmpty());
+        EXPECT_THAT(tx_mr_.total_allocated_bytes, tx_mr_.total_deallocated_bytes);
     }
 
     TimePoint now() const
@@ -143,6 +148,7 @@ protected:
     // NOLINTBEGIN
     libcyphal::VirtualTimeScheduler scheduler_{};
     TrackingMemoryResource          mr_;
+    TrackingMemoryResource          tx_mr_;
     StrictMock<MediaMock>           media_mock_{};
     StrictMock<RxSocketMock>        rx_socket_mock_{"RxS1"};
     StrictMock<TxSocketMock>        tx_socket_mock_{"TxS1"};
@@ -217,6 +223,7 @@ TEST_F(TestUpdTransport, makeTransport_getLocalNodeId)
     // Two media interfaces
     {
         StrictMock<MediaMock> media_mock2;
+        EXPECT_CALL(media_mock2, getTxMemoryResource()).WillRepeatedly(ReturnRef(mr_));
 
         std::array<IMedia*, 3> media_array{&media_mock_, nullptr, &media_mock2};
         auto                   maybe_transport = udp::makeTransport({mr_}, scheduler_, media_array, 0);
@@ -227,6 +234,8 @@ TEST_F(TestUpdTransport, makeTransport_getLocalNodeId)
     {
         StrictMock<MediaMock> media_mock2{};
         StrictMock<MediaMock> media_mock3{};
+        EXPECT_CALL(media_mock2, getTxMemoryResource()).WillRepeatedly(ReturnRef(mr_));
+        EXPECT_CALL(media_mock3, getTxMemoryResource()).WillRepeatedly(ReturnRef(mr_));
 
         std::array<IMedia*, 3> media_array{&media_mock_, &media_mock2, &media_mock3};
         auto                   maybe_transport = udp::makeTransport({mr_}, scheduler_, media_array, 0);
@@ -280,6 +289,7 @@ TEST_F(TestUpdTransport, getProtocolParams)
         .WillRepeatedly(Invoke([&] {          //
             return libcyphal::detail::makeUniquePtr<TxSocketMock::RefWrapper::Spec>(mr_, tx_socket_mock2);
         }));
+    EXPECT_CALL(media_mock2, getTxMemoryResource()).WillRepeatedly(ReturnRef(mr_));
     EXPECT_CALL(tx_socket_mock2, getMtu()).WillRepeatedly(Return(ITxSocket::DefaultMtu));
 
     std::array<IMedia*, 2> media_array{&media_mock_, &media_mock2};
@@ -605,6 +615,7 @@ TEST_F(TestUpdTransport, send_multiframe_payload_to_redundant_not_ready_media)
         .WillRepeatedly(Invoke([this, &tx_socket_mock2] {
             return libcyphal::detail::makeUniquePtr<TxSocketMock::RefWrapper::Spec>(mr_, tx_socket_mock2);
         }));
+    EXPECT_CALL(media_mock2, getTxMemoryResource()).WillRepeatedly(ReturnRef(mr_));
 
     auto transport = makeTransport({mr_}, &media_mock2);
     EXPECT_THAT(transport->setLocalNodeId(0x45), Eq(cetl::nullopt));
@@ -720,6 +731,7 @@ TEST_F(TestUpdTransport, send_payload_to_redundant_fallible_media)
         .WillRepeatedly(Invoke([&] {          //
             return libcyphal::detail::makeUniquePtr<TxSocketMock::RefWrapper::Spec>(mr_, tx_socket_mock2);
         }));
+    EXPECT_CALL(media_mock2, getTxMemoryResource()).WillRepeatedly(ReturnRef(mr_));
 
     auto transport = makeTransport({mr_}, &media_mock2);
     transport->setTransientErrorHandler(std::ref(handler_mock));


### PR DESCRIPTION
These changes (along with necessary changes at lizards) make TX pipeline as "low copy" (see issue #352).
- Memory for TX payload fragments are allocated from `IMedia::getTxMemoryResource()` memory resource.
- Result TX items now contain mutable `MediaPayload` payloads, which are capable to transfer payload memory ownership (f.e. back to the media) - so now it's possible f.e. implement usage of CAN memory hardware for transmission.