### PR TITLE
Fix for issue #412 Only one single RPC client is possible per port

### DIFF
--- a/include/libcyphal/transport/can/can_transport_impl.hpp
+++ b/include/libcyphal/transport/can/can_transport_impl.hpp
@@ -363,7 +363,7 @@ private:
     void onSessionEvent(const SessionEvent::Variant& event_var) noexcept override
     {
         // `visit` might hypothetically throw, so we need to catch it.
-        libcyphal::detail::performWithoutThrowing([this, &event_var] {
+        const auto result = libcyphal::detail::performWithoutThrowing([this, &event_var] {
             //
             cetl::visit(cetl::make_overloaded(  //
                             [this](const SessionEvent::SvcResponseDestroyed& event) noexcept {
@@ -376,6 +376,8 @@ private:
                             }),
                         event_var);
         });
+        (void) result;
+        CETL_DEBUG_ASSERT(result, "");
 
         cancelRxCallbacksIfNoPortsLeft();
         scheduleConfigOfFilters();

--- a/include/libcyphal/transport/can/can_transport_impl.hpp
+++ b/include/libcyphal/transport/can/can_transport_impl.hpp
@@ -11,6 +11,7 @@
 #include "media.hpp"
 #include "msg_rx_session.hpp"
 #include "msg_tx_session.hpp"
+#include "rx_session_tree_node.hpp"
 #include "svc_rx_sessions.hpp"
 #include "svc_tx_sessions.hpp"
 
@@ -19,6 +20,7 @@
 #include "libcyphal/transport/errors.hpp"
 #include "libcyphal/transport/lizard_helpers.hpp"
 #include "libcyphal/transport/msg_sessions.hpp"
+#include "libcyphal/transport/session_tree.hpp"
 #include "libcyphal/transport/svc_sessions.hpp"
 #include "libcyphal/transport/types.hpp"
 #include "libcyphal/types.hpp"
@@ -169,6 +171,7 @@ public:
         , media_array_{std::move(media_array)}
         , total_msg_rx_ports_{0}
         , total_svc_rx_ports_{0}
+        , svc_response_rx_session_nodes_{memory}
     {
         scheduleConfigOfFilters();
     }
@@ -190,6 +193,8 @@ public:
         CETL_DEBUG_ASSERT(total_msg_rx_ports_ == 0,  //
                           "Message sessions must be destroyed before transport.");
         CETL_DEBUG_ASSERT(total_svc_rx_ports_ == 0,  //
+                          "Service sessions must be destroyed before transport.");
+        CETL_DEBUG_ASSERT(svc_response_rx_session_nodes_.isEmpty(),
                           "Service sessions must be destroyed before transport.");
     }
 
@@ -271,41 +276,43 @@ private:
     CETL_NODISCARD Expected<UniquePtr<IMessageRxSession>, AnyFailure> makeMessageRxSession(
         const MessageRxParams& params) override
     {
-        return makeRxSession<IMessageRxSession, MessageRxSession>(CanardTransferKindMessage, params.subject_id, params);
+        return makeRxSessionImpl<IMessageRxSession, MessageRxSession>(  //
+            CanardTransferKindMessage,
+            params.subject_id,
+            params);
     }
 
     CETL_NODISCARD Expected<UniquePtr<IMessageTxSession>, AnyFailure> makeMessageTxSession(
         const MessageTxParams& params) override
     {
-        return MessageTxSession::make(asDelegate(), params);
+        return MessageTxSession::make(memory(), asDelegate(), params);
     }
 
     CETL_NODISCARD Expected<UniquePtr<IRequestRxSession>, AnyFailure> makeRequestRxSession(
         const RequestRxParams& params) override
     {
-        return makeRxSession<IRequestRxSession, SvcRequestRxSession>(CanardTransferKindRequest,
-                                                                     params.service_id,
-                                                                     params);
+        return makeRxSessionImpl<IRequestRxSession, SvcRequestRxSession>(  //
+            CanardTransferKindRequest,
+            params.service_id,
+            params);
     }
 
     CETL_NODISCARD Expected<UniquePtr<IRequestTxSession>, AnyFailure> makeRequestTxSession(
         const RequestTxParams& params) override
     {
-        return SvcRequestTxSession::make(asDelegate(), params);
+        return SvcRequestTxSession::make(memory(), asDelegate(), params);
     }
 
     CETL_NODISCARD Expected<UniquePtr<IResponseRxSession>, AnyFailure> makeResponseRxSession(
         const ResponseRxParams& params) override
     {
-        return makeRxSession<IResponseRxSession, SvcResponseRxSession>(CanardTransferKindResponse,
-                                                                       params.service_id,
-                                                                       params);
+        return makeResponseRxSessionImpl(params);
     }
 
     CETL_NODISCARD Expected<UniquePtr<IResponseTxSession>, AnyFailure> makeResponseTxSession(
         const ResponseTxParams& params) override
     {
-        return SvcResponseTxSession::make(asDelegate(), params);
+        return SvcResponseTxSession::make(memory(), asDelegate(), params);
     }
 
     // MARK: TransportDelegate
@@ -358,13 +365,22 @@ private:
         return cetl::nullopt;
     }
 
-    void onSessionEvent(const SessionEvent::Variant& event_var) override
+    void onSessionEvent(const SessionEvent::Variant& event_var) noexcept override
     {
         SessionEventHandler handler_with{*this};
         cetl::visit(handler_with, event_var);
 
         cancelRxCallbacksIfNoPortsLeft();
         scheduleConfigOfFilters();
+    }
+
+    IRxSessionDelegate* tryFindRxSessionDelegateFor(const ResponseRxParams& params) override
+    {
+        if (auto* const node = svc_response_rx_session_nodes_.tryFindNodeFor(params))
+        {
+            return node->delegate();
+        }
+        return nullptr;
     }
 
     void scheduleConfigOfFilters()
@@ -386,6 +402,9 @@ private:
 
     using Self = TransportImpl;
 
+    template <typename Node>
+    using SessionTree = transport::detail::SessionTree<Node>;
+
     struct SessionEventHandler
     {
         explicit SessionEventHandler(Self& self)
@@ -393,32 +412,42 @@ private:
         {
         }
 
-        void operator()(const SessionEvent::MsgRxLifetime& lifetime) const
+        void operator()(const SessionEvent::MsgCreated&) const
         {
-            if (lifetime.is_added)
-            {
-                ++self_.total_msg_rx_ports_;
-            }
-            else
-            {
-                // We are not going to allow negative number of ports.
-                CETL_DEBUG_ASSERT(self_.total_msg_rx_ports_ > 0, "");
-                self_.total_msg_rx_ports_ -= std::min(static_cast<std::size_t>(1), self_.total_msg_rx_ports_);
-            }
+            ++self_.total_msg_rx_ports_;
         }
 
-        void operator()(const SessionEvent::SvcRxLifetime& lifetime) const
+        void operator()(const SessionEvent::MsgDestroyed&) const
         {
-            if (lifetime.is_added)
-            {
-                ++self_.total_svc_rx_ports_;
-            }
-            else
-            {
-                // We are not going to allow negative number of ports.
-                CETL_DEBUG_ASSERT(self_.total_svc_rx_ports_ > 0, "");
-                self_.total_svc_rx_ports_ -= std::min(static_cast<std::size_t>(1), self_.total_svc_rx_ports_);
-            }
+            // We are not going to allow a negative number of ports.
+            CETL_DEBUG_ASSERT(self_.total_msg_rx_ports_ > 0, "");
+            self_.total_msg_rx_ports_ -= std::min(static_cast<std::size_t>(1), self_.total_msg_rx_ports_);
+        }
+
+        void operator()(const SessionEvent::SvcRequestCreated&) const
+        {
+            ++self_.total_svc_rx_ports_;
+        }
+
+        void operator()(const SessionEvent::SvcRequestDestroyed&) const
+        {
+            // We are not going to allow a negative number of ports.
+            CETL_DEBUG_ASSERT(self_.total_svc_rx_ports_ > 0, "");
+            self_.total_svc_rx_ports_ -= std::min(static_cast<std::size_t>(1), self_.total_svc_rx_ports_);
+        }
+
+        void operator()(const SessionEvent::SvcResponseCreated&) const
+        {
+            ++self_.total_svc_rx_ports_;
+        }
+
+        void operator()(const SessionEvent::SvcResponseDestroyed& event) const
+        {
+            self_.svc_response_rx_session_nodes_.removeNodeFor(event.params);
+
+            // We are not going to allow a negative number of ports.
+            CETL_DEBUG_ASSERT(self_.total_svc_rx_ports_ > 0, "");
+            self_.total_svc_rx_ports_ -= std::min(static_cast<std::size_t>(1), self_.total_svc_rx_ports_);
         }
 
     private:
@@ -426,10 +455,11 @@ private:
 
     };  // SessionEventHandler
 
-    template <typename Interface, typename Factory, typename RxParams>
-    CETL_NODISCARD auto makeRxSession(const CanardTransferKind transfer_kind,
-                                      const PortId             port_id,
-                                      const RxParams&          rx_params) -> Expected<UniquePtr<Interface>, AnyFailure>
+    template <typename Interface, typename Factory, typename Params>
+    CETL_NODISCARD auto makeRxSessionImpl(  //
+        const CanardTransferKind transfer_kind,
+        const PortId             port_id,
+        const Params&            params) -> Expected<UniquePtr<Interface>, AnyFailure>
     {
         const std::int8_t has_port = ::canardRxGetSubscription(&canardInstance(), transfer_kind, port_id, nullptr);
         CETL_DEBUG_ASSERT(has_port >= 0, "There is no way currently to get an error here.");
@@ -438,9 +468,45 @@ private:
             return AlreadyExistsError{};
         }
 
-        auto session_result = Factory::make(asDelegate(), rx_params);
+        auto session_result = Factory::make(memory(), asDelegate(), params);
         if (auto* const make_failure = cetl::get_if<AnyFailure>(&session_result))
         {
+            return std::move(*make_failure);
+        }
+
+        for (Media& media : media_array_)
+        {
+            if (!media.rx_callback())
+            {
+                media.rx_callback() = media.interface().registerPopCallback([this, &media](const auto&) {  //
+                    //
+                    receiveNextFrame(media);
+                });
+            }
+        }
+
+        return session_result;
+    }
+
+    CETL_NODISCARD auto makeResponseRxSessionImpl(  //
+        const ResponseRxParams& params) -> Expected<UniquePtr<IResponseRxSession>, AnyFailure>
+    {
+        // Make sure that session is unique per given parameters.
+        // For response sessions, the uniqueness is based on the service ID and the server node ID.
+        //
+        auto node_result = svc_response_rx_session_nodes_.ensureNodeFor<true>(params);  // should be new
+        if (auto* const failure = cetl::get_if<AnyFailure>(&node_result))
+        {
+            return std::move(*failure);
+        }
+        auto& new_svc_node = cetl::get<RxSessionTreeNode::Response::RefWrapper>(node_result).get();
+
+        auto session_result = SvcResponseRxSession::make(memory(), asDelegate(), params, new_svc_node);
+        if (auto* const make_failure = cetl::get_if<AnyFailure>(&session_result))
+        {
+            // We failed to create the session, so we need to release the unique node.
+            // The sockets we made earlier will be released in the destructor of whole transport.
+            svc_response_rx_session_nodes_.removeNodeFor(params);
             return std::move(*make_failure);
         }
 
@@ -749,6 +815,7 @@ private:
         if (total_msg_rx_ports_ > 0)
         {
             const auto msg_visitor = [&filters](RxSubscription& rx_subscription) {
+                //
                 // Make and store a single message filter.
                 const auto flt = ::canardMakeFilterForSubject(rx_subscription.port_id);
                 filters.emplace_back(Filter{flt.extended_can_id, flt.extended_mask});
@@ -761,6 +828,7 @@ private:
         if ((total_svc_rx_ports_ > 0) && (!is_anonymous))
         {
             const auto svc_visitor = [&filters, local_node_id](RxSubscription& rx_subscription) {
+                //
                 // Make and store a single service filter.
                 const auto flt = ::canardMakeFilterForService(rx_subscription.port_id, local_node_id);
                 filters.emplace_back(Filter{flt.extended_can_id, flt.extended_mask});
@@ -787,12 +855,13 @@ private:
 
     // MARK: Data members:
 
-    IExecutor&            executor_;
-    MediaArray            media_array_;
-    std::size_t           total_msg_rx_ports_;
-    std::size_t           total_svc_rx_ports_;
-    TransientErrorHandler transient_error_handler_;
-    Callback::Any         configure_filters_callback_;
+    IExecutor&                               executor_;
+    MediaArray                               media_array_;
+    std::size_t                              total_msg_rx_ports_;
+    std::size_t                              total_svc_rx_ports_;
+    TransientErrorHandler                    transient_error_handler_;
+    Callback::Any                            configure_filters_callback_;
+    SessionTree<RxSessionTreeNode::Response> svc_response_rx_session_nodes_;
 
 };  // TransportImpl
 

--- a/include/libcyphal/transport/can/can_transport_impl.hpp
+++ b/include/libcyphal/transport/can/can_transport_impl.hpp
@@ -367,7 +367,10 @@ private:
                             //
                             svc_response_rx_session_nodes_.removeNodeFor(event.params);
                         },
-                        [](const auto&) {}),
+                        [](const auto&) {
+                            // No specific action needed for other events.
+                            // But we still might need to reconfigure filters (see below after `visit`).
+                        }),
                     event_var);
 
         cancelRxCallbacksIfNoPortsLeft();

--- a/include/libcyphal/transport/can/can_transport_impl.hpp
+++ b/include/libcyphal/transport/can/can_transport_impl.hpp
@@ -584,16 +584,20 @@ private:
 
             // No Sonar `cpp:S5357` b/c the raw `user_reference` is part of libcanard api,
             // and it was set by us at a RX session constructor (see f.e. `MessageRxSession` ctor).
-            auto* const sesson_delegate =
+            auto* const session_delegate =
                 static_cast<IRxSessionDelegate*>(out_subscription->user_reference);  // NOSONAR cpp:S5357
 
             // No Sonar `cpp:S5356` and `cpp:S5357` b/c we need to pass raw data from C libcanard api.
             auto* const buffer = static_cast<cetl::byte*>(out_transfer.payload.data);  // NOSONAR cpp:S5356 cpp:S5357
 
-            sesson_delegate->acceptRxTransfer(  //
+            const auto transfer_id = static_cast<TransferId>(out_transfer.metadata.transfer_id);
+            const auto priority    = static_cast<Priority>(out_transfer.metadata.priority);
+            const auto timestamp   = TimePoint{std::chrono::microseconds{out_transfer.timestamp_usec}};
+
+            session_delegate->acceptRxTransfer(  //
                 CanardMemory{memory(), out_transfer.payload.allocated_size, buffer, out_transfer.payload.size},
-                out_transfer.metadata,
-                TimePoint{std::chrono::microseconds{out_transfer.timestamp_usec}});
+                TransferRxMetadata{{transfer_id, priority}, timestamp},
+                out_transfer.metadata.remote_node_id);
         }
     }
 

--- a/include/libcyphal/transport/can/delegate.hpp
+++ b/include/libcyphal/transport/can/delegate.hpp
@@ -45,14 +45,12 @@ namespace detail
 class CanardMemory final : public ScatteredBuffer::IStorage
 {
 public:
-    CanardMemory(cetl::pmr::memory_resource& memory,
-                 const std::size_t           allocated_size,
-                 cetl::byte* const           buffer,
-                 const std::size_t           payload_size)
+    // No Sonar `cpp:S5356` and `cpp:S5357` b/c we need to pass raw data from C libcanard api.
+    CanardMemory(cetl::pmr::memory_resource& memory, CanardMutablePayload& payload)
         : memory_{memory}
-        , allocated_size_{allocated_size}
-        , buffer_{buffer}
-        , payload_size_{payload_size}
+        , allocated_size_{std::exchange(payload.allocated_size, 0)}
+        , buffer_{static_cast<cetl::byte*>(std::exchange(payload.data, nullptr))}  // NOSONAR cpp:S5356 cpp:S5357
+        , payload_size_{std::exchange(payload.size, 0)}
     {
     }
     CanardMemory(CanardMemory&& other) noexcept

--- a/include/libcyphal/transport/can/delegate.hpp
+++ b/include/libcyphal/transport/can/delegate.hpp
@@ -225,6 +225,10 @@ public:
 
     };  // CanardConcreteTree
 
+    /// Umbrella type for all session-related events.
+    ///
+    /// These are passed to the `onSessionEvent` method of the transport implementation.
+    ///
     struct SessionEvent
     {
         struct MsgCreated

--- a/include/libcyphal/transport/can/delegate.hpp
+++ b/include/libcyphal/transport/can/delegate.hpp
@@ -69,7 +69,7 @@ public:
         if (buffer_ != nullptr)
         {
             // No Sonar `cpp:S5356` b/c we integrate here with C libcanard memory management.
-            memory_.deallocate(buffer_, allocated_size_);
+            memory_.deallocate(buffer_, allocated_size_);  // NOSONAR cpp:S5356
         }
     }
 

--- a/include/libcyphal/transport/can/delegate.hpp
+++ b/include/libcyphal/transport/can/delegate.hpp
@@ -113,6 +113,8 @@ private:
 
 };  // CanardMemory
 
+// MARK: -
+
 /// This internal session delegate class serves the following purpose: it provides an interface (aka gateway)
 /// to access RX session from transport (by casting canard's `user_reference` member to this class).
 ///
@@ -126,9 +128,9 @@ public:
 
     /// @brief Accepts a received transfer from the transport dedicated to this RX session.
     ///
-    virtual void acceptRxTransfer(CanardMemory&&                canard_memory,
-                                  const CanardTransferMetadata& metadata,
-                                  const TimePoint               timestamp) = 0;
+    virtual void acceptRxTransfer(CanardMemory&&            canard_memory,
+                                  const TransferRxMetadata& rx_metadata,
+                                  const CanardNodeID        source_node_id) = 0;
 
 protected:
     IRxSessionDelegate()  = default;
@@ -565,17 +567,17 @@ private:
     private:
         // IRxSessionDelegate
 
-        void acceptRxTransfer(CanardMemory&&                canard_memory,
-                              const CanardTransferMetadata& metadata,
-                              const TimePoint               timestamp) override
+        void acceptRxTransfer(CanardMemory&&            canard_memory,
+                              const TransferRxMetadata& rx_metadata,
+                              const CanardNodeID        source_node_id) override
         {
             // This is where de-multiplexing happens: the transfer is forwarded to the appropriate session.
             // It's ok not to find the session delegate here - we drop unsolicited transfers.
             //
-            const ResponseRxParams params{0, subscription_.port_id, metadata.remote_node_id};
+            const ResponseRxParams params{0, subscription_.port_id, source_node_id};
             if (auto* const session_delegate = transport_delegate_.tryFindRxSessionDelegateFor(params))
             {
-                session_delegate->acceptRxTransfer(std::move(canard_memory), metadata, timestamp);
+                session_delegate->acceptRxTransfer(std::move(canard_memory), rx_metadata, source_node_id);
             }
         }
 

--- a/include/libcyphal/transport/can/delegate.hpp
+++ b/include/libcyphal/transport/can/delegate.hpp
@@ -128,7 +128,7 @@ public:
     ///
     virtual void acceptRxTransfer(CanardMemory&&            canard_memory,
                                   const TransferRxMetadata& rx_metadata,
-                                  const CanardNodeID        source_node_id) = 0;
+                                  const NodeId              source_node_id) = 0;
 
 protected:
     IRxSessionDelegate()  = default;
@@ -571,7 +571,7 @@ private:
 
         void acceptRxTransfer(CanardMemory&&            canard_memory,
                               const TransferRxMetadata& rx_metadata,
-                              const CanardNodeID        source_node_id) override
+                              const NodeId              source_node_id) override
         {
             // This is where de-multiplexing happens: the transfer is forwarded to the appropriate session.
             // It's ok not to find the session delegate here - we drop unsolicited transfers.

--- a/include/libcyphal/transport/can/delegate.hpp
+++ b/include/libcyphal/transport/can/delegate.hpp
@@ -126,7 +126,7 @@ public:
 
     /// @brief Accepts a received transfer from the transport dedicated to this RX session.
     ///
-    virtual void acceptRxTransfer(CanardMemory&&            canard_memory,
+    virtual void acceptRxTransfer(CanardMemory&&            lizard_memory,
                                   const TransferRxMetadata& rx_metadata,
                                   const NodeId              source_node_id) = 0;
 
@@ -569,7 +569,7 @@ private:
     private:
         // IRxSessionDelegate
 
-        void acceptRxTransfer(CanardMemory&&            canard_memory,
+        void acceptRxTransfer(CanardMemory&&            lizard_memory,
                               const TransferRxMetadata& rx_metadata,
                               const NodeId              source_node_id) override
         {
@@ -579,7 +579,7 @@ private:
             const ResponseRxParams params{0, subscription_.port_id, source_node_id};
             if (auto* const session_delegate = transport_delegate_.tryFindRxSessionDelegateFor(params))
             {
-                session_delegate->acceptRxTransfer(std::move(canard_memory), rx_metadata, source_node_id);
+                session_delegate->acceptRxTransfer(std::move(lizard_memory), rx_metadata, source_node_id);
             }
         }
 

--- a/include/libcyphal/transport/can/msg_rx_session.hpp
+++ b/include/libcyphal/transport/can/msg_rx_session.hpp
@@ -130,19 +130,16 @@ private:
 
     // MARK: IRxSessionDelegate
 
-    void acceptRxTransfer(CanardMemory&&                canard_memory,
-                          const CanardTransferMetadata& metadata,
-                          const TimePoint               timestamp) override
+    void acceptRxTransfer(CanardMemory&&            canard_memory,
+                          const TransferRxMetadata& rx_metadata,
+                          const CanardNodeID        source_node_id) override
     {
-        const auto priority    = static_cast<Priority>(metadata.priority);
-        const auto transfer_id = static_cast<TransferId>(metadata.transfer_id);
-
         const cetl::optional<NodeId> publisher_node_id =  //
-            metadata.remote_node_id > CANARD_NODE_ID_MAX  //
+            source_node_id > CANARD_NODE_ID_MAX           //
                 ? cetl::nullopt
-                : cetl::make_optional<NodeId>(metadata.remote_node_id);
+                : cetl::make_optional<NodeId>(source_node_id);
 
-        const MessageRxMetadata meta{{{transfer_id, priority}, timestamp}, publisher_node_id};
+        const MessageRxMetadata meta{rx_metadata, publisher_node_id};
         MessageRxTransfer       msg_rx_transfer{meta, ScatteredBuffer{std::move(canard_memory)}};
         if (on_receive_cb_fn_)
         {

--- a/include/libcyphal/transport/can/msg_rx_session.hpp
+++ b/include/libcyphal/transport/can/msg_rx_session.hpp
@@ -132,12 +132,10 @@ private:
 
     void acceptRxTransfer(CanardMemory&&            canard_memory,
                           const TransferRxMetadata& rx_metadata,
-                          const CanardNodeID        source_node_id) override
+                          const NodeId              source_node_id) override
     {
-        const cetl::optional<NodeId> publisher_node_id =  //
-            source_node_id > CANARD_NODE_ID_MAX           //
-                ? cetl::nullopt
-                : cetl::make_optional<NodeId>(source_node_id);
+        const cetl::optional<NodeId> publisher_node_id =
+            source_node_id > CANARD_NODE_ID_MAX ? cetl::nullopt : cetl::make_optional(source_node_id);
 
         const MessageRxMetadata meta{rx_metadata, publisher_node_id};
         MessageRxTransfer       msg_rx_transfer{meta, ScatteredBuffer{std::move(canard_memory)}};

--- a/include/libcyphal/transport/can/msg_rx_session.hpp
+++ b/include/libcyphal/transport/can/msg_rx_session.hpp
@@ -130,7 +130,7 @@ private:
 
     // MARK: IRxSessionDelegate
 
-    void acceptRxTransfer(CanardMemory&&            canard_memory,
+    void acceptRxTransfer(CanardMemory&&            lizard_memory,
                           const TransferRxMetadata& rx_metadata,
                           const NodeId              source_node_id) override
     {
@@ -138,7 +138,7 @@ private:
             source_node_id > CANARD_NODE_ID_MAX ? cetl::nullopt : cetl::make_optional(source_node_id);
 
         const MessageRxMetadata meta{rx_metadata, publisher_node_id};
-        MessageRxTransfer       msg_rx_transfer{meta, ScatteredBuffer{std::move(canard_memory)}};
+        MessageRxTransfer       msg_rx_transfer{meta, ScatteredBuffer{std::move(lizard_memory)}};
         if (on_receive_cb_fn_)
         {
             on_receive_cb_fn_(OnReceiveCallback::Arg{msg_rx_transfer});

--- a/include/libcyphal/transport/can/msg_tx_session.hpp
+++ b/include/libcyphal/transport/can/msg_tx_session.hpp
@@ -42,15 +42,17 @@ class MessageTxSession final : public IMessageTxSession
     };
 
 public:
-    CETL_NODISCARD static Expected<UniquePtr<IMessageTxSession>, AnyFailure> make(TransportDelegate&     delegate,
-                                                                                  const MessageTxParams& params)
+    CETL_NODISCARD static Expected<UniquePtr<IMessageTxSession>, AnyFailure> make(  //
+        cetl::pmr::memory_resource& memory,
+        TransportDelegate&          delegate,
+        const MessageTxParams&      params)
     {
         if (params.subject_id > CANARD_SUBJECT_ID_MAX)
         {
             return ArgumentError{};
         }
 
-        auto session = libcyphal::detail::makeUniquePtr<Spec>(delegate.memory(), Spec{}, delegate, params);
+        auto session = libcyphal::detail::makeUniquePtr<Spec>(memory, Spec{}, delegate, params);
         if (session == nullptr)
         {
             return MemoryError{};

--- a/include/libcyphal/transport/can/rx_session_tree_node.hpp
+++ b/include/libcyphal/transport/can/rx_session_tree_node.hpp
@@ -23,6 +23,11 @@ namespace detail
 
 class IRxSessionDelegate;
 
+/// Umbrella type for various RX session tree nodes in use at the CAN transport.
+///
+/// Currently, it contains only one `Response` subtype,
+/// but still kept nested to match the UDP transport approach (where there are several subtypes).
+///
 struct RxSessionTreeNode
 {
     /// @brief Represents a service response RX session node.

--- a/include/libcyphal/transport/can/rx_session_tree_node.hpp
+++ b/include/libcyphal/transport/can/rx_session_tree_node.hpp
@@ -34,38 +34,7 @@ struct RxSessionTreeNode
 {
     /// @brief Represents a service response RX session node.
     ///
-    class Response final : public transport::detail::SessionTree<Response>::NodeBase
-    {
-    public:
-        explicit Response(const ResponseRxParams& params, const std::tuple<>&)
-            : service_id_{params.service_id}
-            , server_node_id{params.server_node_id}
-            , delegate_{nullptr}
-        {
-        }
-
-        CETL_NODISCARD std::int32_t compareByParams(const ResponseRxParams& params) const
-        {
-            if (service_id_ != params.service_id)
-            {
-                return static_cast<std::int32_t>(service_id_) - static_cast<std::int32_t>(params.service_id);
-            }
-            return static_cast<std::int32_t>(server_node_id) - static_cast<std::int32_t>(params.server_node_id);
-        }
-
-        CETL_NODISCARD IRxSessionDelegate*& delegate() noexcept
-        {
-            return delegate_;
-        }
-
-    private:
-        // MARK: Data members:
-
-        const PortId        service_id_;
-        const NodeId        server_node_id;
-        IRxSessionDelegate* delegate_;
-
-    };  // Response
+    using Response = transport::detail::ResponseRxSessionNode<IRxSessionDelegate>;
 
 };  // RxSessionTreeNode
 

--- a/include/libcyphal/transport/can/rx_session_tree_node.hpp
+++ b/include/libcyphal/transport/can/rx_session_tree_node.hpp
@@ -7,13 +7,6 @@
 #define LIBCYPHAL_TRANSPORT_CAN_RX_SESSION_TREE_NODE_HPP_INCLUDED
 
 #include "libcyphal/transport/session_tree.hpp"
-#include "libcyphal/transport/svc_sessions.hpp"
-#include "libcyphal/transport/types.hpp"
-
-#include <cetl/cetl.hpp>
-
-#include <cstdint>
-#include <tuple>
 
 namespace libcyphal
 {

--- a/include/libcyphal/transport/can/rx_session_tree_node.hpp
+++ b/include/libcyphal/transport/can/rx_session_tree_node.hpp
@@ -1,0 +1,77 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef LIBCYPHAL_TRANSPORT_CAN_RX_SESSION_TREE_NODE_HPP_INCLUDED
+#define LIBCYPHAL_TRANSPORT_CAN_RX_SESSION_TREE_NODE_HPP_INCLUDED
+
+#include "libcyphal/transport/session_tree.hpp"
+#include "libcyphal/transport/svc_sessions.hpp"
+#include "libcyphal/transport/types.hpp"
+
+#include <cetl/cetl.hpp>
+
+#include <cstdint>
+#include <tuple>
+
+namespace libcyphal
+{
+namespace transport
+{
+namespace can
+{
+
+/// Internal implementation details of the UDP transport.
+/// Not supposed to be used directly by the users of the library.
+///
+namespace detail
+{
+
+class IRxSessionDelegate;
+
+struct RxSessionTreeNode
+{
+    /// @brief Represents a service response RX session node.
+    ///
+    class Response final : public transport::detail::SessionTree<Response>::NodeBase
+    {
+    public:
+        explicit Response(const ResponseRxParams& params, const std::tuple<>&)
+            : service_id_{params.service_id}
+            , server_node_id{params.server_node_id}
+            , delegate_{nullptr}
+        {
+        }
+
+        CETL_NODISCARD std::int32_t compareByParams(const ResponseRxParams& params) const
+        {
+            if (service_id_ != params.service_id)
+            {
+                return static_cast<std::int32_t>(service_id_) - static_cast<std::int32_t>(params.service_id);
+            }
+            return static_cast<std::int32_t>(server_node_id) - static_cast<std::int32_t>(params.server_node_id);
+        }
+
+        CETL_NODISCARD IRxSessionDelegate*& delegate() noexcept
+        {
+            return delegate_;
+        }
+
+    private:
+        // MARK: Data members:
+
+        const PortId        service_id_;
+        const NodeId        server_node_id;
+        IRxSessionDelegate* delegate_;
+
+    };  // Response
+
+};  // RxSessionTreeNode
+
+}  // namespace detail
+}  // namespace can
+}  // namespace transport
+}  // namespace libcyphal
+
+#endif  // LIBCYPHAL_TRANSPORT_CAN_RX_SESSION_TREE_NODE_HPP_INCLUDED

--- a/include/libcyphal/transport/can/svc_rx_sessions.hpp
+++ b/include/libcyphal/transport/can/svc_rx_sessions.hpp
@@ -85,19 +85,13 @@ protected:
 
     // MARK: IRxSessionDelegate
 
-    void acceptRxTransfer(const CanardRxTransfer& transfer) final
+    void acceptRxTransfer(CanardMemory&&                canard_memory,
+                          const CanardTransferMetadata& metadata,
+                          const TimePoint               timestamp) final
     {
-        const auto priority       = static_cast<Priority>(transfer.metadata.priority);
-        const auto remote_node_id = static_cast<NodeId>(transfer.metadata.remote_node_id);
-        const auto transfer_id    = static_cast<TransferId>(transfer.metadata.transfer_id);
-        const auto timestamp      = TimePoint{std::chrono::microseconds{transfer.timestamp_usec}};
-
-        // No Sonar `cpp:S5356` and `cpp:S5357` b/c we need to pass raw data from C libcanard api.
-        auto* const buffer = static_cast<cetl::byte*>(transfer.payload.data);  // NOSONAR cpp:S5356 cpp:S5357
-        TransportDelegate::CanardMemory canard_memory{delegate_,
-                                                      transfer.payload.allocated_size,
-                                                      buffer,
-                                                      transfer.payload.size};
+        const auto priority       = static_cast<Priority>(metadata.priority);
+        const auto remote_node_id = static_cast<NodeId>(metadata.remote_node_id);
+        const auto transfer_id    = static_cast<TransferId>(metadata.transfer_id);
 
         const ServiceRxMetadata meta{{{transfer_id, priority}, timestamp}, remote_node_id};
         ServiceRxTransfer       svc_rx_transfer{meta, ScatteredBuffer{std::move(canard_memory)}};

--- a/include/libcyphal/transport/can/svc_rx_sessions.hpp
+++ b/include/libcyphal/transport/can/svc_rx_sessions.hpp
@@ -10,8 +10,8 @@
 
 #include "libcyphal/errors.hpp"
 #include "libcyphal/transport/errors.hpp"
+#include "libcyphal/transport/svc_rx_session_base.hpp"
 #include "libcyphal/transport/svc_sessions.hpp"
-#include "libcyphal/transport/types.hpp"
 #include "libcyphal/types.hpp"
 
 #include <canard.h>
@@ -19,8 +19,6 @@
 #include <cetl/pf17/cetlpf.hpp>
 
 #include <chrono>
-#include <cstdint>
-#include <utility>
 
 namespace libcyphal
 {
@@ -35,85 +33,11 @@ namespace can
 namespace detail
 {
 
-/// @brief A base class to represent a service RX session.
-///
-template <typename Interface_, typename Params>
-class SvcRxSessionBase : public IRxSessionDelegate, public Interface_
-{
-public:
-    SvcRxSessionBase(TransportDelegate& delegate, const Params& params)
-        : delegate_{delegate}
-        , params_{params}
-    {
-    }
-
-    SvcRxSessionBase(const SvcRxSessionBase&)                = delete;
-    SvcRxSessionBase(SvcRxSessionBase&&) noexcept            = delete;
-    SvcRxSessionBase& operator=(const SvcRxSessionBase&)     = delete;
-    SvcRxSessionBase& operator=(SvcRxSessionBase&&) noexcept = delete;
-
-protected:
-    ~SvcRxSessionBase() = default;
-
-    TransportDelegate& delegate()
-    {
-        return delegate_;
-    }
-
-    // MARK: Interface
-
-    CETL_NODISCARD Params getParams() const noexcept final
-    {
-        return params_;
-    }
-
-    CETL_NODISCARD cetl::optional<ServiceRxTransfer> receive() final
-    {
-        if (last_rx_transfer_)
-        {
-            auto transfer = std::move(*last_rx_transfer_);
-            last_rx_transfer_.reset();
-            return transfer;
-        }
-        return cetl::nullopt;
-    }
-
-    void setOnReceiveCallback(ISvcRxSession::OnReceiveCallback::Function&& function) final
-    {
-        on_receive_cb_fn_ = std::move(function);
-    }
-
-    // MARK: IRxSessionDelegate
-
-    void acceptRxTransfer(CanardMemory&&            canard_memory,
-                          const TransferRxMetadata& rx_metadata,
-                          const CanardNodeID        source_node_id) final
-    {
-        const ServiceRxMetadata meta{rx_metadata, source_node_id};
-        ServiceRxTransfer       svc_rx_transfer{meta, ScatteredBuffer{std::move(canard_memory)}};
-        if (on_receive_cb_fn_)
-        {
-            on_receive_cb_fn_(ISvcRxSession::OnReceiveCallback::Arg{svc_rx_transfer});
-            return;
-        }
-        (void) last_rx_transfer_.emplace(std::move(svc_rx_transfer));
-    }
-
-private:
-    // MARK: Data members:
-
-    TransportDelegate&                         delegate_;
-    const Params                               params_;
-    cetl::optional<ServiceRxTransfer>          last_rx_transfer_;
-    ISvcRxSession::OnReceiveCallback::Function on_receive_cb_fn_;
-
-};  // SvcRxSessionBase
-
-// MARK: -
-
 /// @brief A concrete class to represent a service request RX session (aka server side).
 ///
-class SvcRequestRxSession final : public SvcRxSessionBase<IRequestRxSession, RequestRxParams>
+class SvcRequestRxSession final
+    : public transport::detail::  //
+      SvcRxSessionBase<IRequestRxSession, IRxSessionDelegate, TransportDelegate, RequestRxParams, CanardMemory>
 {
     /// @brief Defines private specification for making interface unique ptr.
     ///
@@ -191,7 +115,9 @@ private:
 
 /// @brief A concrete class to represent a service response RX session (aka client side).
 ///
-class SvcResponseRxSession final : public SvcRxSessionBase<IResponseRxSession, ResponseRxParams>
+class SvcResponseRxSession final
+    : public transport::detail::  //
+      SvcRxSessionBase<IResponseRxSession, IRxSessionDelegate, TransportDelegate, ResponseRxParams, CanardMemory>
 {
     /// @brief Defines private specification for making interface unique ptr.
     ///

--- a/include/libcyphal/transport/can/svc_rx_sessions.hpp
+++ b/include/libcyphal/transport/can/svc_rx_sessions.hpp
@@ -85,15 +85,11 @@ protected:
 
     // MARK: IRxSessionDelegate
 
-    void acceptRxTransfer(CanardMemory&&                canard_memory,
-                          const CanardTransferMetadata& metadata,
-                          const TimePoint               timestamp) final
+    void acceptRxTransfer(CanardMemory&&            canard_memory,
+                          const TransferRxMetadata& rx_metadata,
+                          const CanardNodeID        source_node_id) final
     {
-        const auto priority       = static_cast<Priority>(metadata.priority);
-        const auto remote_node_id = static_cast<NodeId>(metadata.remote_node_id);
-        const auto transfer_id    = static_cast<TransferId>(metadata.transfer_id);
-
-        const ServiceRxMetadata meta{{{transfer_id, priority}, timestamp}, remote_node_id};
+        const ServiceRxMetadata meta{rx_metadata, source_node_id};
         ServiceRxTransfer       svc_rx_transfer{meta, ScatteredBuffer{std::move(canard_memory)}};
         if (on_receive_cb_fn_)
         {

--- a/include/libcyphal/transport/can/svc_tx_sessions.hpp
+++ b/include/libcyphal/transport/can/svc_tx_sessions.hpp
@@ -44,15 +44,17 @@ class SvcRequestTxSession final : public IRequestTxSession
     };
 
 public:
-    CETL_NODISCARD static Expected<UniquePtr<IRequestTxSession>, AnyFailure> make(TransportDelegate&     delegate,
-                                                                                  const RequestTxParams& params)
+    CETL_NODISCARD static Expected<UniquePtr<IRequestTxSession>, AnyFailure> make(  //
+        cetl::pmr::memory_resource& memory,
+        TransportDelegate&          delegate,
+        const RequestTxParams&      params)
     {
         if ((params.service_id > CANARD_SERVICE_ID_MAX) || (params.server_node_id > CANARD_NODE_ID_MAX))
         {
             return ArgumentError{};
         }
 
-        auto session = libcyphal::detail::makeUniquePtr<Spec>(delegate.memory(), Spec{}, delegate, params);
+        auto session = libcyphal::detail::makeUniquePtr<Spec>(memory, Spec{}, delegate, params);
         if (session == nullptr)
         {
             return MemoryError{};
@@ -119,15 +121,17 @@ class SvcResponseTxSession final : public IResponseTxSession
     };
 
 public:
-    CETL_NODISCARD static Expected<UniquePtr<IResponseTxSession>, AnyFailure> make(TransportDelegate&      delegate,
-                                                                                   const ResponseTxParams& params)
+    CETL_NODISCARD static Expected<UniquePtr<IResponseTxSession>, AnyFailure> make(  //
+        cetl::pmr::memory_resource& memory,
+        TransportDelegate&          delegate,
+        const ResponseTxParams&     params)
     {
         if (params.service_id > CANARD_SERVICE_ID_MAX)
         {
             return ArgumentError{};
         }
 
-        auto session = libcyphal::detail::makeUniquePtr<Spec>(delegate.memory(), Spec{}, delegate, params);
+        auto session = libcyphal::detail::makeUniquePtr<Spec>(memory, Spec{}, delegate, params);
         if (session == nullptr)
         {
             return MemoryError{};

--- a/include/libcyphal/transport/session.hpp
+++ b/include/libcyphal/transport/session.hpp
@@ -48,9 +48,14 @@ public:
 
     /// @brief Sets the timeout for a transmission.
     ///
+    /// Note that b/c of the nature of the Lizard libraries, the timeout is shared
+    /// between different sessions of the same kind and port id. This means that
+    /// the timeout set for one session will affect all other sessions of the same kind and port id.
+    /// For example, two RPC clients (on the same service id) of two different RPC server nodes
+    /// will share the same timeout for transfer ids.
     /// See Cyphal specification about transfer-ID timeouts.
     ///
-    /// @param timeout - Positive duration for the timeout. Default value is 2 second.
+    /// @param timeout - Positive duration for the timeout. The default value is 2 seconds.
     ///                  Zero or negative values are ignored.
     ///
     virtual void setTransferIdTimeout(const Duration timeout) = 0;

--- a/include/libcyphal/transport/session_tree.hpp
+++ b/include/libcyphal/transport/session_tree.hpp
@@ -1,0 +1,165 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef LIBCYPHAL_TRANSPORT_SESSION_TREE_HPP_INCLUDED
+#define LIBCYPHAL_TRANSPORT_SESSION_TREE_HPP_INCLUDED
+
+#include "errors.hpp"
+#include "libcyphal/common/cavl/cavl.hpp"
+#include "libcyphal/types.hpp"
+
+#include <cetl/cetl.hpp>
+#include <cetl/pf17/cetlpf.hpp>
+
+#include <array>
+#include <functional>
+#include <tuple>
+
+namespace libcyphal
+{
+namespace transport
+{
+
+/// Internal implementation details of the UDP transport.
+/// Not supposed to be used directly by the users of the library.
+///
+namespace detail
+{
+
+/// @brief Defines a tree of sessions for the UDP transport.
+///
+template <typename Node>
+class SessionTree final
+{
+public:
+    /// Base class for the session tree node.
+    ///
+    class NodeBase : public common::cavl::Node<Node>
+    {
+    public:
+        using common::cavl::Node<Node>::getChildNode;
+        using RefWrapper = std::reference_wrapper<Node>;
+
+        NodeBase(const NodeBase&)                = delete;
+        NodeBase(NodeBase&&) noexcept            = delete;
+        NodeBase& operator=(const NodeBase&)     = delete;
+        NodeBase& operator=(NodeBase&&) noexcept = delete;
+
+    protected:
+        NodeBase()  = default;
+        ~NodeBase() = default;
+
+    };  // NodeBase
+
+    explicit SessionTree(cetl::pmr::memory_resource& mr)
+        : allocator_{&mr}
+    {
+    }
+
+    SessionTree(const SessionTree&)                = delete;
+    SessionTree(SessionTree&&) noexcept            = delete;
+    SessionTree& operator=(const SessionTree&)     = delete;
+    SessionTree& operator=(SessionTree&&) noexcept = delete;
+
+    ~SessionTree()
+    {
+        nodes_.traversePostOrder([this](auto& node) { destroyNode(node); });
+    }
+
+    CETL_NODISCARD bool isEmpty() const noexcept
+    {
+        return nodes_.empty();
+    }
+
+    template <bool ShouldBeNew = false, typename Params, typename... Args>
+    CETL_NODISCARD auto ensureNodeFor(const Params& params,
+                                      Args&&... args) -> Expected<typename NodeBase::RefWrapper, AnyFailure>
+    {
+        auto args_tuple = std::make_tuple(std::forward<Args>(args)...);
+
+        const auto node_existing = nodes_.search(
+            [&params](const Node& node) {  // predicate
+                //
+                return node.compareByParams(params);
+            },
+            [this, &params, args_tuple_ = std::move(args_tuple)] {
+                //
+                return constructNewNode(params, std::move(args_tuple_));
+            });
+
+        auto* const node = std::get<0>(node_existing);
+        if (nullptr == node)
+        {
+            return MemoryError{};
+        }
+        if (ShouldBeNew && std::get<1>(node_existing))
+        {
+            return AlreadyExistsError{};
+        }
+
+        return *node;
+    }
+
+    template <typename Params>
+    CETL_NODISCARD Node* tryFindNodeFor(const Params& params)
+    {
+        return nodes_.search([&params](const Node& node) {  // predicate
+            //
+            return node.compareByParams(params);
+        });
+    }
+
+    template <typename Params>
+    void removeNodeFor(const Params& params)
+    {
+        removeAndDestroyNode(tryFindNodeFor(params));
+    }
+
+    template <typename Action>
+    CETL_NODISCARD cetl::optional<AnyFailure> forEachNode(Action&& action)
+    {
+        return nodes_.traverse(std::forward<Action>(action));
+    }
+
+private:
+    template <typename Params, typename ArgsTuple>
+    CETL_NODISCARD Node* constructNewNode(const Params& params, ArgsTuple&& args_tuple)
+    {
+        Node* const node = allocator_.allocate(1);
+        if (nullptr != node)
+        {
+            allocator_.construct(node, params, std::forward<ArgsTuple>(args_tuple));
+        }
+        return node;
+    }
+
+    void removeAndDestroyNode(Node* node)
+    {
+        if (nullptr != node)
+        {
+            nodes_.remove(node);
+            destroyNode(*node);
+        }
+    }
+
+    void destroyNode(Node& node)
+    {
+        // No Sonar cpp:M23_329 b/c we do our own low-level PMR management here.
+        node.~Node();  // NOSONAR cpp:M23_329
+        allocator_.deallocate(&node, 1);
+    }
+
+    // MARK: Data members:
+
+    common::cavl::Tree<Node>              nodes_;
+    libcyphal::detail::PmrAllocator<Node> allocator_;
+
+};  // SessionTree
+
+}  // namespace detail
+}  // namespace transport
+}  // namespace libcyphal
+
+#endif  // LIBCYPHAL_TRANSPORT_SESSION_TREE_HPP_INCLUDED

--- a/include/libcyphal/transport/session_tree.hpp
+++ b/include/libcyphal/transport/session_tree.hpp
@@ -112,7 +112,7 @@ public:
     }
 
     template <typename Params>
-    void removeNodeFor(const Params& params)
+    void removeNodeFor(const Params& params) noexcept
     {
         removeAndDestroyNode(tryFindNodeFor(params));
     }

--- a/include/libcyphal/transport/session_tree.hpp
+++ b/include/libcyphal/transport/session_tree.hpp
@@ -75,8 +75,8 @@ public:
     }
 
     template <bool ShouldBeNew = false, typename Params, typename... Args>
-    CETL_NODISCARD auto ensureNodeFor(const Params& params, Args&&... args)
-        -> Expected<typename NodeBase::RefWrapper, AnyFailure>
+    CETL_NODISCARD auto ensureNodeFor(const Params& params,
+                                      Args&&... args) -> Expected<typename NodeBase::RefWrapper, AnyFailure>
     {
         auto args_tuple = std::make_tuple(std::forward<Args>(args)...);
 

--- a/include/libcyphal/transport/svc_rx_session_base.hpp
+++ b/include/libcyphal/transport/svc_rx_session_base.hpp
@@ -1,0 +1,111 @@
+/// @copyright
+/// Copyright (C) OpenCyphal Development Team  <opencyphal.org>
+/// Copyright Amazon.com Inc. or its affiliates.
+/// SPDX-License-Identifier: MIT
+
+#ifndef LIBCYPHAL_TRANSPORT_SVC_RX_SESSION_BASE_HPP_INCLUDED
+#define LIBCYPHAL_TRANSPORT_SVC_RX_SESSION_BASE_HPP_INCLUDED
+
+#include "scattered_buffer.hpp"
+
+#include <cetl/cetl.hpp>
+#include <cetl/pf17/cetlpf.hpp>
+
+#include <utility>
+
+namespace libcyphal
+{
+namespace transport
+{
+
+/// Internal implementation details of a transport.
+/// Not supposed to be used directly by the users of the library.
+///
+namespace detail
+{
+
+/// @brief A base template class to represent a service RX session.
+///
+/// Should be suitable for any transport.
+///
+template <typename Interface,
+          typename IRxSessionDelegate,
+          typename TransportDelegate,
+          typename Params,
+          typename LizardMemory>
+class SvcRxSessionBase : public IRxSessionDelegate, public Interface
+{
+public:
+    SvcRxSessionBase(TransportDelegate& delegate, const Params& params)
+        : delegate_{delegate}
+        , params_{params}
+    {
+    }
+
+    SvcRxSessionBase(const SvcRxSessionBase&)                = delete;
+    SvcRxSessionBase(SvcRxSessionBase&&) noexcept            = delete;
+    SvcRxSessionBase& operator=(const SvcRxSessionBase&)     = delete;
+    SvcRxSessionBase& operator=(SvcRxSessionBase&&) noexcept = delete;
+
+protected:
+    ~SvcRxSessionBase() = default;
+
+    TransportDelegate& delegate()
+    {
+        return delegate_;
+    }
+
+    // MARK: Interface
+
+    CETL_NODISCARD Params getParams() const noexcept final
+    {
+        return params_;
+    }
+
+    CETL_NODISCARD cetl::optional<ServiceRxTransfer> receive() final
+    {
+        if (last_rx_transfer_)
+        {
+            auto transfer = std::move(*last_rx_transfer_);
+            last_rx_transfer_.reset();
+            return transfer;
+        }
+        return cetl::nullopt;
+    }
+
+    void setOnReceiveCallback(ISvcRxSession::OnReceiveCallback::Function&& function) final
+    {
+        on_receive_cb_fn_ = std::move(function);
+    }
+
+    // MARK: IRxSessionDelegate
+
+    void acceptRxTransfer(LizardMemory&&            lizard_memory,
+                          const TransferRxMetadata& rx_metadata,
+                          const NodeId              source_node_id) final
+    {
+        const ServiceRxMetadata meta{rx_metadata, source_node_id};
+        ServiceRxTransfer       svc_rx_transfer{meta, ScatteredBuffer{std::move(lizard_memory)}};
+        if (on_receive_cb_fn_)
+        {
+            on_receive_cb_fn_(ISvcRxSession::OnReceiveCallback::Arg{svc_rx_transfer});
+            return;
+        }
+        (void) last_rx_transfer_.emplace(std::move(svc_rx_transfer));
+    }
+
+private:
+    // MARK: Data members:
+
+    TransportDelegate&                         delegate_;
+    const Params                               params_;
+    cetl::optional<ServiceRxTransfer>          last_rx_transfer_;
+    ISvcRxSession::OnReceiveCallback::Function on_receive_cb_fn_;
+
+};  // SvcRxSessionBase
+
+}  // namespace detail
+}  // namespace transport
+}  // namespace libcyphal
+
+#endif  // LIBCYPHAL_TRANSPORT_SVC_RX_SESSION_BASE_HPP_INCLUDED

--- a/include/libcyphal/transport/udp/delegate.hpp
+++ b/include/libcyphal/transport/udp/delegate.hpp
@@ -490,7 +490,7 @@ private:
         RxRpcPortDemuxNode& operator=(const RxRpcPortDemuxNode&)     = delete;
         RxRpcPortDemuxNode& operator=(RxRpcPortDemuxNode&&) noexcept = delete;
 
-        virtual ~RxRpcPortDemuxNode()
+        ~RxRpcPortDemuxNode()
         {
             transport_delegate_.cancelRxRpcPortFor(port_, false);  // response
         }

--- a/include/libcyphal/transport/udp/delegate.hpp
+++ b/include/libcyphal/transport/udp/delegate.hpp
@@ -216,7 +216,7 @@ public:
     ///
     virtual void acceptRxTransfer(UdpardMemory&&            udpard_memory,
                                   const TransferRxMetadata& rx_metadata,
-                                  const UdpardNodeID        source_node_id) = 0;
+                                  const NodeId              source_node_id) = 0;
 
 protected:
     IRxSessionDelegate()  = default;
@@ -521,7 +521,7 @@ private:
 
         void acceptRxTransfer(UdpardMemory&&            udpard_memory,
                               const TransferRxMetadata& rx_metadata,
-                              const UdpardNodeID        source_node_id) override
+                              const NodeId              source_node_id) override
         {
             // This is where de-multiplexing happens: the transfer is forwarded to the appropriate session.
             // It's ok not to find the session delegate here - we drop unsolicited transfers.

--- a/include/libcyphal/transport/udp/delegate.hpp
+++ b/include/libcyphal/transport/udp/delegate.hpp
@@ -343,7 +343,7 @@ public:
         return nullptr;
     }
 
-    void releaseRxRpcPortFor(const ResponseRxParams& params)
+    void releaseRxRpcPortFor(const ResponseRxParams& params) noexcept
     {
         if (auto* const node = rx_rpc_port_demux_nodes_.tryFindNodeFor(params))
         {
@@ -354,7 +354,7 @@ public:
         }
     }
 
-    void cancelRxRpcPortFor(const UdpardRxRPCPort& rpc_port_, const bool is_request)
+    void cancelRxRpcPortFor(const UdpardRxRPCPort& rpc_port_, const bool is_request) noexcept
     {
         const std::int8_t result = ::udpardRxRPCDispatcherCancel(&rx_rpc_dispatcher_,
                                                                  rpc_port_.service_id,

--- a/include/libcyphal/transport/udp/delegate.hpp
+++ b/include/libcyphal/transport/udp/delegate.hpp
@@ -214,7 +214,7 @@ public:
 
     /// @brief Accepts a received transfer from the transport dedicated to this RX session.
     ///
-    virtual void acceptRxTransfer(UdpardMemory&&            udpard_memory,
+    virtual void acceptRxTransfer(UdpardMemory&&            lizard_memory,
                                   const TransferRxMetadata& rx_metadata,
                                   const NodeId              source_node_id) = 0;
 
@@ -519,7 +519,7 @@ private:
     private:
         // IRxSessionDelegate
 
-        void acceptRxTransfer(UdpardMemory&&            udpard_memory,
+        void acceptRxTransfer(UdpardMemory&&            lizard_memory,
                               const TransferRxMetadata& rx_metadata,
                               const NodeId              source_node_id) override
         {
@@ -529,7 +529,7 @@ private:
             const ResponseRxParams params{0, port_.service_id, source_node_id};
             if (auto* const session_delegate = transport_delegate_.tryFindRxSessionDelegateFor(params))
             {
-                session_delegate->acceptRxTransfer(std::move(udpard_memory), rx_metadata, source_node_id);
+                session_delegate->acceptRxTransfer(std::move(lizard_memory), rx_metadata, source_node_id);
             }
         }
 

--- a/include/libcyphal/transport/udp/delegate.hpp
+++ b/include/libcyphal/transport/udp/delegate.hpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <tuple>
 #include <utility>
 
 namespace libcyphal
@@ -474,8 +475,8 @@ private:
     class RxRpcPortDemuxNode final : public RxSessionTreeNode::Base<RxRpcPortDemuxNode>, public IRxSessionDelegate
     {
     public:
-        RxRpcPortDemuxNode(const ResponseRxParams& params, TransportDelegate& transport_delegate)
-            : transport_delegate_{transport_delegate}
+        RxRpcPortDemuxNode(const ResponseRxParams& params, std::tuple<TransportDelegate&> args_tuple)
+            : transport_delegate_{std::get<0>(args_tuple)}
             , ref_count_{0}
             , port_{}
         {

--- a/include/libcyphal/transport/udp/msg_rx_session.hpp
+++ b/include/libcyphal/transport/udp/msg_rx_session.hpp
@@ -97,7 +97,7 @@ public:
     {
         ::udpardRxSubscriptionFree(&subscription_);
 
-        delegate_.onSessionEvent(TransportDelegate::SessionEvent::MsgDestroyed{params_.subject_id});
+        delegate_.onSessionEvent(TransportDelegate::SessionEvent::MsgDestroyed{params_});
     }
 
     // In use (public) for unit tests only.

--- a/include/libcyphal/transport/udp/msg_rx_session.hpp
+++ b/include/libcyphal/transport/udp/msg_rx_session.hpp
@@ -142,7 +142,7 @@ private:
 
     // MARK: IRxSessionDelegate
 
-    void acceptRxTransfer(UdpardMemory&&            udpard_memory,
+    void acceptRxTransfer(UdpardMemory&&            lizard_memory,
                           const TransferRxMetadata& rx_metadata,
                           const NodeId              source_node_id) override
     {
@@ -150,7 +150,7 @@ private:
             source_node_id > UDPARD_NODE_ID_MAX ? cetl::nullopt : cetl::make_optional(source_node_id);
 
         const MessageRxMetadata meta{rx_metadata, publisher_node_id};
-        MessageRxTransfer       msg_rx_transfer{meta, ScatteredBuffer{std::move(udpard_memory)}};
+        MessageRxTransfer       msg_rx_transfer{meta, ScatteredBuffer{std::move(lizard_memory)}};
         if (on_receive_cb_fn_)
         {
             on_receive_cb_fn_(OnReceiveCallback::Arg{msg_rx_transfer});

--- a/include/libcyphal/transport/udp/msg_rx_session.hpp
+++ b/include/libcyphal/transport/udp/msg_rx_session.hpp
@@ -142,20 +142,16 @@ private:
 
     // MARK: IRxSessionDelegate
 
-    void acceptRxTransfer(UdpardRxTransfer& inout_transfer) override
+    void acceptRxTransfer(UdpardMemory&&            udpard_memory,
+                          const TransferRxMetadata& rx_metadata,
+                          const UdpardNodeID        source_node_id) override
     {
-        const auto transfer_id = inout_transfer.transfer_id;
-        const auto priority    = static_cast<Priority>(inout_transfer.priority);
-        const auto timestamp   = TimePoint{std::chrono::microseconds{inout_transfer.timestamp_usec}};
-
-        const cetl::optional<NodeId> publisher_node_id =
-            inout_transfer.source_node_id > UDPARD_NODE_ID_MAX
+        const cetl::optional<NodeId> publisher_node_id =  //
+            source_node_id > UDPARD_NODE_ID_MAX           //
                 ? cetl::nullopt
-                : cetl::make_optional<NodeId>(inout_transfer.source_node_id);
+                : cetl::make_optional<NodeId>(source_node_id);
 
-        TransportDelegate::UdpardMemory udpard_memory{delegate_, inout_transfer};
-
-        const MessageRxMetadata meta{{{transfer_id, priority}, timestamp}, publisher_node_id};
+        const MessageRxMetadata meta{rx_metadata, publisher_node_id};
         MessageRxTransfer       msg_rx_transfer{meta, ScatteredBuffer{std::move(udpard_memory)}};
         if (on_receive_cb_fn_)
         {

--- a/include/libcyphal/transport/udp/msg_rx_session.hpp
+++ b/include/libcyphal/transport/udp/msg_rx_session.hpp
@@ -7,7 +7,6 @@
 #define LIBCYPHAL_TRANSPORT_UDP_MSG_RX_SESSION_HPP_INCLUDED
 
 #include "delegate.hpp"
-#include "session_tree.hpp"
 
 #include "libcyphal/errors.hpp"
 #include "libcyphal/transport/errors.hpp"
@@ -50,7 +49,7 @@ class MessageRxSession final : private IMsgRxSessionDelegate, public IMessageRxS
     };
 
 public:
-    CETL_NODISCARD static Expected<UniquePtr<IMessageRxSession>, AnyFailure> make(
+    CETL_NODISCARD static Expected<UniquePtr<IMessageRxSession>, AnyFailure> make(  //
         cetl::pmr::memory_resource& memory,
         TransportDelegate&          delegate,
         const MessageRxParams&      params,

--- a/include/libcyphal/transport/udp/msg_rx_session.hpp
+++ b/include/libcyphal/transport/udp/msg_rx_session.hpp
@@ -144,12 +144,10 @@ private:
 
     void acceptRxTransfer(UdpardMemory&&            udpard_memory,
                           const TransferRxMetadata& rx_metadata,
-                          const UdpardNodeID        source_node_id) override
+                          const NodeId              source_node_id) override
     {
-        const cetl::optional<NodeId> publisher_node_id =  //
-            source_node_id > UDPARD_NODE_ID_MAX           //
-                ? cetl::nullopt
-                : cetl::make_optional<NodeId>(source_node_id);
+        const cetl::optional<NodeId> publisher_node_id =
+            source_node_id > UDPARD_NODE_ID_MAX ? cetl::nullopt : cetl::make_optional(source_node_id);
 
         const MessageRxMetadata meta{rx_metadata, publisher_node_id};
         MessageRxTransfer       msg_rx_transfer{meta, ScatteredBuffer{std::move(udpard_memory)}};

--- a/include/libcyphal/transport/udp/msg_tx_session.hpp
+++ b/include/libcyphal/transport/udp/msg_tx_session.hpp
@@ -44,9 +44,10 @@ class MessageTxSession final : public IMessageTxSession
     };
 
 public:
-    CETL_NODISCARD static Expected<UniquePtr<IMessageTxSession>, AnyFailure> make(cetl::pmr::memory_resource& memory,
-                                                                                  TransportDelegate&          delegate,
-                                                                                  const MessageTxParams&      params)
+    CETL_NODISCARD static Expected<UniquePtr<IMessageTxSession>, AnyFailure> make(  //
+        cetl::pmr::memory_resource& memory,
+        TransportDelegate&          delegate,
+        const MessageTxParams&      params)
     {
         if (params.subject_id > UDPARD_SUBJECT_ID_MAX)
         {

--- a/include/libcyphal/transport/udp/rx_session_tree_node.hpp
+++ b/include/libcyphal/transport/udp/rx_session_tree_node.hpp
@@ -46,6 +46,8 @@ struct SocketState
 class IRxSessionDelegate;
 class IMsgRxSessionDelegate;
 
+/// Umbrella type for various RX session tree nodes in use at the UDP transport.
+///
 struct RxSessionTreeNode
 {
     /// @brief Represents a message RX session node.
@@ -53,6 +55,9 @@ struct RxSessionTreeNode
     class Message final : public transport::detail::SessionTree<Message>::NodeBase
     {
     public:
+        // Empty tuple parameter is used to allow for the same constructor signature
+        // as for other session nodes (see also `SessionTree::ensureNodeFor` method).
+        //
         explicit Message(const MessageRxParams& params, const std::tuple<>&)
             : subject_id_{params.subject_id}
         {
@@ -90,6 +95,9 @@ struct RxSessionTreeNode
     class Request final : public transport::detail::SessionTree<Request>::NodeBase
     {
     public:
+        // Empty tuple parameter is used to allow for the same constructor signature
+        // as for other session nodes (see also `SessionTree::ensureNodeFor` method).
+        //
         explicit Request(const RequestRxParams& params, const std::tuple<>&)
             : service_id_{params.service_id}
         {

--- a/include/libcyphal/transport/udp/rx_session_tree_node.hpp
+++ b/include/libcyphal/transport/udp/rx_session_tree_node.hpp
@@ -3,21 +3,19 @@
 /// Copyright Amazon.com Inc. or its affiliates.
 /// SPDX-License-Identifier: MIT
 
-#ifndef LIBCYPHAL_TRANSPORT_UDP_SESSION_TREE_HPP_INCLUDED
-#define LIBCYPHAL_TRANSPORT_UDP_SESSION_TREE_HPP_INCLUDED
+#ifndef LIBCYPHAL_TRANSPORT_UDP_RX_SESSION_TREE_NODE_HPP_INCLUDED
+#define LIBCYPHAL_TRANSPORT_UDP_RX_SESSION_TREE_NODE_HPP_INCLUDED
 
 #include "tx_rx_sockets.hpp"
 
-#include "libcyphal/common/cavl/cavl.hpp"
 #include "libcyphal/executor.hpp"
-#include "libcyphal/transport/errors.hpp"
 #include "libcyphal/transport/msg_sessions.hpp"
+#include "libcyphal/transport/session_tree.hpp"
 #include "libcyphal/transport/svc_sessions.hpp"
 #include "libcyphal/transport/types.hpp"
 #include "libcyphal/types.hpp"
 
 #include <cetl/cetl.hpp>
-#include <cetl/pf17/cetlpf.hpp>
 #include <udpard.h>
 
 #include <array>
@@ -46,137 +44,14 @@ struct SocketState
 
 };  // SocketState
 
-/// @brief Defines a tree of sessions for the UDP transport.
-///
-template <typename Node>
-class SessionTree final
-{
-public:
-    using NodeRef = std::reference_wrapper<Node>;
-
-    explicit SessionTree(cetl::pmr::memory_resource& mr)
-        : allocator_{&mr}
-    {
-    }
-
-    SessionTree(const SessionTree&)                = delete;
-    SessionTree(SessionTree&&) noexcept            = delete;
-    SessionTree& operator=(const SessionTree&)     = delete;
-    SessionTree& operator=(SessionTree&&) noexcept = delete;
-
-    ~SessionTree()
-    {
-        nodes_.traversePostOrder([this](auto& node) { destroyNode(node); });
-    }
-
-    CETL_NODISCARD bool isEmpty() const noexcept
-    {
-        return nodes_.empty();
-    }
-
-    template <bool ShouldBeNew = false, typename Params, typename... Args>
-    CETL_NODISCARD Expected<NodeRef, AnyFailure> ensureNodeFor(const Params& params, Args&&... args)
-    {
-        auto args_tuple = std::make_tuple(std::forward<Args>(args)...);
-
-        const auto node_existing = nodes_.search(
-            [&params](const Node& node) {  // predicate
-                //
-                return node.compareByParams(params);
-            },
-            [this, &params, args_tuple_ = std::move(args_tuple)] {
-                //
-                return constructNewNode(params, std::move(args_tuple_));
-            });
-
-        auto* const node = std::get<0>(node_existing);
-        if (nullptr == node)
-        {
-            return MemoryError{};
-        }
-        if (ShouldBeNew && std::get<1>(node_existing))
-        {
-            return AlreadyExistsError{};
-        }
-
-        return *node;
-    }
-
-    template <typename Params>
-    CETL_NODISCARD Node* tryFindNodeFor(const Params& params)
-    {
-        return nodes_.search([&params](const Node& node) {  // predicate
-            //
-            return node.compareByParams(params);
-        });
-    }
-
-    template <typename Params>
-    void removeNodeFor(const Params& params)
-    {
-        removeAndDestroyNode(tryFindNodeFor(params));
-    }
-
-    template <typename Action>
-    CETL_NODISCARD cetl::optional<AnyFailure> forEachNode(Action&& action)
-    {
-        return nodes_.traverse(std::forward<Action>(action));
-    }
-
-private:
-    template <typename Params, typename ArgsTuple>
-    CETL_NODISCARD Node* constructNewNode(const Params& params, ArgsTuple&& args_tuple)
-    {
-        Node* const node = allocator_.allocate(1);
-        if (nullptr != node)
-        {
-            allocator_.construct(node, params, std::forward<ArgsTuple>(args_tuple));
-        }
-        return node;
-    }
-
-    void removeAndDestroyNode(Node* node)
-    {
-        if (nullptr != node)
-        {
-            nodes_.remove(node);
-            destroyNode(*node);
-        }
-    }
-
-    void destroyNode(Node& node)
-    {
-        // No Sonar cpp:M23_329 b/c we do our own low-level PMR management here.
-        node.~Node();  // NOSONAR cpp:M23_329
-        allocator_.deallocate(&node, 1);
-    }
-
-    // MARK: Data members:
-
-    common::cavl::Tree<Node>              nodes_;
-    libcyphal::detail::PmrAllocator<Node> allocator_;
-
-};  // SessionTree
-
-// MARK: -
-
 class IRxSessionDelegate;
 class IMsgRxSessionDelegate;
 
 struct RxSessionTreeNode
 {
-    template <typename Derived>
-    class Base : public common::cavl::Node<Derived>
-    {
-    public:
-        using common::cavl::Node<Derived>::getChildNode;
-        using ReferenceWrapper = std::reference_wrapper<Derived>;
-
-    };  // Base
-
     /// @brief Represents a message RX session node.
     ///
-    class Message final : public Base<Message>
+    class Message final : public transport::detail::SessionTree<Message>::NodeBase
     {
     public:
         explicit Message(const MessageRxParams& params, const std::tuple<>&)
@@ -213,7 +88,7 @@ struct RxSessionTreeNode
 
     /// @brief Represents a service request RX session node.
     ///
-    class Request final : public Base<Request>
+    class Request final : public transport::detail::SessionTree<Request>::NodeBase
     {
     public:
         explicit Request(const RequestRxParams& params, const std::tuple<>&)
@@ -235,7 +110,7 @@ struct RxSessionTreeNode
 
     /// @brief Represents a service response RX session node.
     ///
-    class Response final : public Base<Response>
+    class Response final : public transport::detail::SessionTree<Response>::NodeBase
     {
     public:
         explicit Response(const ResponseRxParams& params, const std::tuple<>&)
@@ -275,4 +150,4 @@ struct RxSessionTreeNode
 }  // namespace transport
 }  // namespace libcyphal
 
-#endif  // LIBCYPHAL_TRANSPORT_UDP_SESSION_TREE_HPP_INCLUDED
+#endif  // LIBCYPHAL_TRANSPORT_UDP_RX_SESSION_TREE_NODE_HPP_INCLUDED

--- a/include/libcyphal/transport/udp/rx_session_tree_node.hpp
+++ b/include/libcyphal/transport/udp/rx_session_tree_node.hpp
@@ -20,7 +20,6 @@
 
 #include <array>
 #include <cstdint>
-#include <functional>
 #include <tuple>
 
 namespace libcyphal

--- a/include/libcyphal/transport/udp/rx_session_tree_node.hpp
+++ b/include/libcyphal/transport/udp/rx_session_tree_node.hpp
@@ -110,38 +110,7 @@ struct RxSessionTreeNode
 
     /// @brief Represents a service response RX session node.
     ///
-    class Response final : public transport::detail::SessionTree<Response>::NodeBase
-    {
-    public:
-        explicit Response(const ResponseRxParams& params, const std::tuple<>&)
-            : service_id_{params.service_id}
-            , server_node_id{params.server_node_id}
-            , delegate_{nullptr}
-        {
-        }
-
-        CETL_NODISCARD std::int32_t compareByParams(const ResponseRxParams& params) const
-        {
-            if (service_id_ != params.service_id)
-            {
-                return static_cast<std::int32_t>(service_id_) - static_cast<std::int32_t>(params.service_id);
-            }
-            return static_cast<std::int32_t>(server_node_id) - static_cast<std::int32_t>(params.server_node_id);
-        }
-
-        CETL_NODISCARD IRxSessionDelegate*& delegate() noexcept
-        {
-            return delegate_;
-        }
-
-    private:
-        // MARK: Data members:
-
-        const PortId        service_id_;
-        const NodeId        server_node_id;
-        IRxSessionDelegate* delegate_;
-
-    };  // Response
+    using Response = transport::detail::ResponseRxSessionNode<IRxSessionDelegate>;
 
 };  // RxSessionTreeNode
 

--- a/include/libcyphal/transport/udp/session_tree.hpp
+++ b/include/libcyphal/transport/udp/session_tree.hpp
@@ -84,9 +84,9 @@ public:
                 //
                 return node.compareByParams(params);
             },
-            [this, &params, args_tuple = std::move(args_tuple)] {
+            [this, &params, args_tuple_ = std::move(args_tuple)] {
                 //
-                return constructNewNode(params, std::move(args_tuple));
+                return constructNewNode(params, std::move(args_tuple_));
             });
 
         auto* const node = std::get<0>(node_existing);

--- a/include/libcyphal/transport/udp/session_tree.hpp
+++ b/include/libcyphal/transport/udp/session_tree.hpp
@@ -81,7 +81,7 @@ public:
                 //
                 return node.compareByParams(params);
             },
-            [&] {
+            [this, &params, &args...] {
                 //
                 return constructNewNode(params, std::forward<Args>(args)...);
             });

--- a/include/libcyphal/transport/udp/svc_rx_sessions.hpp
+++ b/include/libcyphal/transport/udp/svc_rx_sessions.hpp
@@ -103,6 +103,7 @@ protected:
         (void) last_rx_transfer_.emplace(std::move(svc_rx_transfer));
     }
 
+private:
     // MARK: Data members:
 
     TransportDelegate&                         delegate_;
@@ -132,7 +133,7 @@ public:
         cetl::pmr::memory_resource& memory,
         TransportDelegate&          delegate,
         const RequestRxParams&      params,
-        RxSessionTreeNode::Request&)
+        const RxSessionTreeNode::Request&)
     {
         if (params.service_id > UDPARD_SERVICE_ID_MAX)
         {
@@ -166,7 +167,7 @@ public:
     ~SvcRequestRxSession()
     {
         delegate().cancelRxRpcPortFor(rpc_port_, true);  // request
-        delegate().onSessionEvent(TransportDelegate::SessionEvent::SvcRequestDestroyed{params_});
+        delegate().onSessionEvent(TransportDelegate::SessionEvent::SvcRequestDestroyed{getParams()});
     }
 
     // In use (public) for unit tests only.
@@ -249,8 +250,8 @@ public:
 
     ~SvcResponseRxSession()
     {
-        delegate().releaseRxRpcPortFor(params_);
-        delegate().onSessionEvent(TransportDelegate::SessionEvent::SvcResponseDestroyed{params_});
+        delegate().releaseRxRpcPortFor(getParams());
+        delegate().onSessionEvent(TransportDelegate::SessionEvent::SvcResponseDestroyed{getParams()});
     }
 
 private:
@@ -263,7 +264,7 @@ private:
         const auto timeout_us = std::chrono::duration_cast<std::chrono::microseconds>(timeout);
         if (timeout_us >= Duration::zero())
         {
-            if (auto* const rpc_port = delegate_.findRxRpcPortFor(params_))
+            if (auto* const rpc_port = delegate().findRxRpcPortFor(getParams()))
             {
                 rpc_port->port.transfer_id_timeout_usec = static_cast<UdpardMicrosecond>(timeout_us.count());
             }

--- a/include/libcyphal/transport/udp/svc_rx_sessions.hpp
+++ b/include/libcyphal/transport/udp/svc_rx_sessions.hpp
@@ -148,7 +148,7 @@ public:
         : Base{delegate, params}
         , rpc_port_{}
     {
-        delegate.listenForRxRpcPort(rpc_port_, params);
+        delegate.listenForRxRpcPort<true>(rpc_port_, params);
 
         // No Sonar `cpp:S5356` b/c we integrate here with C libudpard API.
         rpc_port_.user_reference = static_cast<IRxSessionDelegate*>(this);  // NOSONAR cpp:S5356

--- a/include/libcyphal/transport/udp/svc_rx_sessions.hpp
+++ b/include/libcyphal/transport/udp/svc_rx_sessions.hpp
@@ -84,16 +84,11 @@ protected:
 
     // MARK: IRxSessionDelegate
 
-    void acceptRxTransfer(UdpardRxTransfer& inout_transfer) final
+    void acceptRxTransfer(UdpardMemory&&            udpard_memory,
+                          const TransferRxMetadata& rx_metadata,
+                          const UdpardNodeID        source_node_id) final
     {
-        const auto transfer_id    = inout_transfer.transfer_id;
-        const auto remote_node_id = inout_transfer.source_node_id;
-        const auto priority       = static_cast<Priority>(inout_transfer.priority);
-        const auto timestamp      = TimePoint{std::chrono::microseconds{inout_transfer.timestamp_usec}};
-
-        TransportDelegate::UdpardMemory udpard_memory{delegate_, inout_transfer};
-
-        const ServiceRxMetadata meta{{{transfer_id, priority}, timestamp}, remote_node_id};
+        const ServiceRxMetadata meta{rx_metadata, source_node_id};
         ServiceRxTransfer       svc_rx_transfer{meta, ScatteredBuffer{std::move(udpard_memory)}};
         if (on_receive_cb_fn_)
         {

--- a/include/libcyphal/transport/udp/svc_tx_sessions.hpp
+++ b/include/libcyphal/transport/udp/svc_tx_sessions.hpp
@@ -46,9 +46,10 @@ class SvcRequestTxSession final : public IRequestTxSession
     };
 
 public:
-    CETL_NODISCARD static Expected<UniquePtr<IRequestTxSession>, AnyFailure> make(cetl::pmr::memory_resource& memory,
-                                                                                  TransportDelegate&          delegate,
-                                                                                  const RequestTxParams&      params)
+    CETL_NODISCARD static Expected<UniquePtr<IRequestTxSession>, AnyFailure> make(  //
+        cetl::pmr::memory_resource& memory,
+        TransportDelegate&          delegate,
+        const RequestTxParams&      params)
     {
         if ((params.service_id > UDPARD_SERVICE_ID_MAX) || (params.server_node_id > UDPARD_NODE_ID_MAX))
         {
@@ -125,9 +126,10 @@ class SvcResponseTxSession final : public IResponseTxSession
     };
 
 public:
-    CETL_NODISCARD static Expected<UniquePtr<IResponseTxSession>, AnyFailure> make(cetl::pmr::memory_resource& memory,
-                                                                                   TransportDelegate&          delegate,
-                                                                                   const ResponseTxParams&     params)
+    CETL_NODISCARD static Expected<UniquePtr<IResponseTxSession>, AnyFailure> make(  //
+        cetl::pmr::memory_resource& memory,
+        TransportDelegate&          delegate,
+        const ResponseTxParams&     params)
     {
         if (params.service_id > UDPARD_SERVICE_ID_MAX)
         {

--- a/include/libcyphal/transport/udp/udp_transport_impl.hpp
+++ b/include/libcyphal/transport/udp/udp_transport_impl.hpp
@@ -388,7 +388,7 @@ private:
     void onSessionEvent(const SessionEvent::Variant& event_var) noexcept override
     {
         // `visit` might hypothetically throw, so we need to catch it.
-        libcyphal::detail::performWithoutThrowing([this, &event_var] {
+        const auto result = libcyphal::detail::performWithoutThrowing([this, &event_var] {
             //
             cetl::visit(cetl::make_overloaded(  //
                             [this](const SessionEvent::MsgDestroyed& msg_session_destroyed) noexcept {
@@ -407,6 +407,8 @@ private:
                             }),
                         event_var);
         });
+        (void) result;
+        CETL_DEBUG_ASSERT(result, "");
     }
 
     IRxSessionDelegate* tryFindRxSessionDelegateFor(const ResponseRxParams& params) override

--- a/include/libcyphal/transport/udp/udp_transport_impl.hpp
+++ b/include/libcyphal/transport/udp/udp_transport_impl.hpp
@@ -387,7 +387,7 @@ private:
 
     void onSessionEvent(const SessionEvent::Variant& event_var) noexcept override
     {
-        cetl::visit(cetl::make_overloaded(
+        cetl::visit(cetl::make_overloaded(  //
                         [this](const SessionEvent::MsgDestroyed& msg_session_destroyed) {
                             //
                             msg_rx_session_nodes_.removeNodeFor(msg_session_destroyed.params);

--- a/include/libcyphal/types.hpp
+++ b/include/libcyphal/types.hpp
@@ -169,7 +169,6 @@ CETL_NODISCARD bool performWithoutThrowing(Action&& action) noexcept
 #if defined(__cpp_exceptions)
     } catch (const Exception& ex)
     {
-        CETL_DEBUG_ASSERT(false, ex.what());
         return false;
     }
 #endif

--- a/include/libcyphal/types.hpp
+++ b/include/libcyphal/types.hpp
@@ -149,6 +149,24 @@ CETL_NODISCARD UpVariant upcastVariant(Variant&& variant)
                        std::forward<Variant>(variant));
 }
 
+template <typename Action>
+bool performWithoutThrowing(Action&& action) noexcept
+{
+#if defined(__cpp_exceptions)
+    try
+#endif
+    {
+        std::forward<Action>(action)();
+        return true;
+    }
+#if defined(__cpp_exceptions)
+    catch (...)
+    {
+        return false;
+    }
+#endif
+}
+
 }  // namespace detail
 
 /// @brief A deleter which uses Polymorphic Memory Resource (PMR) for de-allocation of raw bytes memory buffers.

--- a/include/libcyphal/types.hpp
+++ b/include/libcyphal/types.hpp
@@ -152,7 +152,7 @@ CETL_NODISCARD UpVariant upcastVariant(Variant&& variant)
 
 /// @brief Wraps the given action into a lambda and performs it without throwing exceptions.
 ///
-/// In use f.e. for `cetl::visit` which might hypothetically throw an exceptions.
+/// In use f.e. for `cetl::visit` which might hypothetically throw an exception.
 ///
 /// @return `true` if the action was performed successfully, `false` if an exception was thrown.
 ///         Always `true` if exceptions are disabled.

--- a/include/libcyphal/types.hpp
+++ b/include/libcyphal/types.hpp
@@ -154,13 +154,12 @@ bool performWithoutThrowing(Action&& action) noexcept
 {
 #if defined(__cpp_exceptions)
     try
-#endif
     {
+#endif
         std::forward<Action>(action)();
         return true;
-    }
 #if defined(__cpp_exceptions)
-    catch (...)
+    } catch (...)
     {
         return false;
     }

--- a/include/libcyphal/types.hpp
+++ b/include/libcyphal/types.hpp
@@ -150,7 +150,7 @@ CETL_NODISCARD UpVariant upcastVariant(Variant&& variant)
                        std::forward<Variant>(variant));
 }
 
-/// @brief Wraps the given action into a lambda and performs it without throwing exceptions.
+/// @brief Wraps the given action into a try/catch block, and performs it without throwing the given exception type.
 ///
 /// In use f.e. for `cetl::visit` which might hypothetically throw an exception.
 ///
@@ -166,6 +166,7 @@ CETL_NODISCARD bool performWithoutThrowing(Action&& action) noexcept
 #endif
         std::forward<Action>(action)();
         return true;
+
 #if defined(__cpp_exceptions)
     } catch (const Exception& ex)
     {

--- a/test/unittest/transport/can/test_can_delegate.cpp
+++ b/test/unittest/transport/can/test_can_delegate.cpp
@@ -12,6 +12,7 @@
 #include <libcyphal/errors.hpp>
 #include <libcyphal/transport/can/delegate.hpp>
 #include <libcyphal/transport/errors.hpp>
+#include <libcyphal/transport/svc_sessions.hpp>
 #include <libcyphal/transport/types.hpp>
 #include <libcyphal/types.hpp>
 
@@ -52,7 +53,9 @@ using testing::VariantWith;
 class TestCanDelegate : public testing::Test
 {
 protected:
-    class TransportDelegateImpl final : public detail::TransportDelegate
+    using TransportDelegate = can::detail::TransportDelegate;
+
+    class TransportDelegateImpl final : public TransportDelegate
     {
     public:
         explicit TransportDelegateImpl(cetl::pmr::memory_resource& memory)
@@ -68,7 +71,13 @@ protected:
                      const CanardTransferMetadata& metadata,
                      const PayloadFragments        payload_fragments),
                     (override));
-        MOCK_METHOD(void, onSessionEvent, (const SessionEvent::Variant& event_var), (override));
+
+        MOCK_METHOD(void, onSessionEvent, (const SessionEvent::Variant& event_var), (noexcept, override));
+
+        MOCK_METHOD(can::detail::IRxSessionDelegate*,
+                    tryFindRxSessionDelegateFor,
+                    (const ResponseRxParams& params),
+                    (override));
     };
 
     void SetUp() override
@@ -93,15 +102,15 @@ protected:
 
 TEST_F(TestCanDelegate, CanardMemory_copy)
 {
-    using CanardMemory = detail::TransportDelegate::CanardMemory;
+    using CanardMemory = TransportDelegate::CanardMemory;
 
     TransportDelegateImpl delegate{mr_};
     auto&                 canard_instance = delegate.canardInstance();
 
-    const std::size_t payload_size   = 4;
-    const std::size_t allocated_size = payload_size + 1;
-    auto* const       payload        = static_cast<byte*>(
-        canard_instance.memory.allocate(static_cast<detail::TransportDelegate*>(&delegate), allocated_size));
+    constexpr std::size_t payload_size   = 4;
+    constexpr std::size_t allocated_size = payload_size + 1;
+    auto* const           payload        = static_cast<byte*>(
+        canard_instance.memory.allocate(static_cast<TransportDelegate*>(&delegate), allocated_size));
     fillIotaBytes({payload, allocated_size}, b('0'));
 
     const CanardMemory canard_memory{delegate, allocated_size, payload, payload_size};
@@ -109,7 +118,7 @@ TEST_F(TestCanDelegate, CanardMemory_copy)
 
     // Ask exactly as payload
     {
-        const std::size_t          ask_size = payload_size;
+        constexpr std::size_t      ask_size = payload_size;
         std::array<byte, ask_size> buffer{};
 
         EXPECT_THAT(canard_memory.copy(0, buffer.data(), ask_size), ask_size);
@@ -118,7 +127,7 @@ TEST_F(TestCanDelegate, CanardMemory_copy)
 
     // Ask more than payload
     {
-        const std::size_t          ask_size = payload_size + 2;
+        constexpr std::size_t      ask_size = payload_size + 2;
         std::array<byte, ask_size> buffer{};
 
         EXPECT_THAT(canard_memory.copy(0, buffer.data(), ask_size), payload_size);
@@ -127,7 +136,7 @@ TEST_F(TestCanDelegate, CanardMemory_copy)
 
     // Ask less than payload (with different offsets)
     {
-        const std::size_t          ask_size = payload_size - 2;
+        constexpr std::size_t      ask_size = payload_size - 2;
         std::array<byte, ask_size> buffer{};
 
         EXPECT_THAT(canard_memory.copy(0, buffer.data(), ask_size), ask_size);
@@ -153,14 +162,14 @@ TEST_F(TestCanDelegate, CanardMemory_copy)
 
 TEST_F(TestCanDelegate, CanardMemory_copy_on_moved)
 {
-    using CanardMemory = can::detail::TransportDelegate::CanardMemory;
+    using CanardMemory = TransportDelegate::CanardMemory;
 
     TransportDelegateImpl delegate{mr_};
     auto&                 canard_instance = delegate.canardInstance();
 
     constexpr std::size_t payload_size = 4;
     auto* const           payload      = static_cast<byte*>(
-        canard_instance.memory.allocate(static_cast<detail::TransportDelegate*>(&delegate), payload_size));
+        canard_instance.memory.allocate(static_cast<TransportDelegate*>(&delegate), payload_size));
     fillIotaBytes({payload, payload_size}, b('0'));
 
     CanardMemory old_canard_memory{delegate, payload_size, payload, payload_size};
@@ -179,7 +188,7 @@ TEST_F(TestCanDelegate, CanardMemory_copy_on_moved)
         EXPECT_THAT(buffer, Each(b('\0')));
     }
 
-    // Try new one
+    // Try a new one
     {
         std::array<byte, payload_size> buffer{};
         EXPECT_THAT(new_canard_memory.copy(0, buffer.data(), buffer.size()), payload_size);
@@ -189,15 +198,15 @@ TEST_F(TestCanDelegate, CanardMemory_copy_on_moved)
 
 TEST_F(TestCanDelegate, optAnyFailureFromCanard)
 {
-    EXPECT_THAT(can::detail::TransportDelegate::optAnyFailureFromCanard(-CANARD_ERROR_OUT_OF_MEMORY),
+    EXPECT_THAT(TransportDelegate::optAnyFailureFromCanard(-CANARD_ERROR_OUT_OF_MEMORY),
                 Optional(VariantWith<MemoryError>(_)));
 
-    EXPECT_THAT(can::detail::TransportDelegate::optAnyFailureFromCanard(-CANARD_ERROR_INVALID_ARGUMENT),
+    EXPECT_THAT(TransportDelegate::optAnyFailureFromCanard(-CANARD_ERROR_INVALID_ARGUMENT),
                 Optional(VariantWith<libcyphal::ArgumentError>(_)));
 
-    EXPECT_THAT(can::detail::TransportDelegate::optAnyFailureFromCanard(0), Eq(cetl::nullopt));
-    EXPECT_THAT(can::detail::TransportDelegate::optAnyFailureFromCanard(1), Eq(cetl::nullopt));
-    EXPECT_THAT(can::detail::TransportDelegate::optAnyFailureFromCanard(-1), Eq(cetl::nullopt));
+    EXPECT_THAT(TransportDelegate::optAnyFailureFromCanard(0), Eq(cetl::nullopt));
+    EXPECT_THAT(TransportDelegate::optAnyFailureFromCanard(1), Eq(cetl::nullopt));
+    EXPECT_THAT(TransportDelegate::optAnyFailureFromCanard(-1), Eq(cetl::nullopt));
 }
 
 TEST_F(TestCanDelegate, canardMemoryAllocate_no_memory)
@@ -205,13 +214,13 @@ TEST_F(TestCanDelegate, canardMemoryAllocate_no_memory)
     StrictMock<MemoryResourceMock> mr_mock;
 
     TransportDelegateImpl delegate{mr_mock};
-    auto&                 canard_instance = delegate.canardInstance();
+    const auto&           canard_instance = delegate.canardInstance();
 
     // Emulate that there is no memory at all.
     EXPECT_CALL(mr_mock, do_allocate(_, _))  //
         .WillOnce(Return(nullptr));
 
-    EXPECT_THAT(canard_instance.memory.allocate(static_cast<detail::TransportDelegate*>(&delegate), 1), IsNull());
+    EXPECT_THAT(canard_instance.memory.allocate(static_cast<TransportDelegate*>(&delegate), 1), IsNull());
 }
 
 TEST_F(TestCanDelegate, CanardConcreteTree_visitCounting)
@@ -248,7 +257,7 @@ TEST_F(TestCanDelegate, CanardConcreteTree_visitCounting)
     right_rl.up             = &right_r;
     right_r.lr[0]           = &right_rl;
 
-    using MyTree = can::detail::TransportDelegate::CanardConcreteTree<const MyNode>;
+    using MyTree = TransportDelegate::CanardConcreteTree<const MyNode>;
     {
         std::vector<std::string> names;
         auto count = MyTree::visitCounting(&root, [&names](const MyNode& node) { names.push_back(node.name); });

--- a/test/unittest/transport/can/test_can_delegate.cpp
+++ b/test/unittest/transport/can/test_can_delegate.cpp
@@ -112,8 +112,12 @@ TEST_F(TestCanDelegate, CanardMemory_copy)
         static_cast<byte*>(canard_instance.memory.allocate(static_cast<TransportDelegate*>(&delegate), allocated_size));
     fillIotaBytes({payload, allocated_size}, b('0'));
 
-    const CanardMemory canard_memory{mr_, allocated_size, payload, payload_size};
+    CanardMutablePayload canard_payload{payload_size, payload, allocated_size};
+    const CanardMemory canard_memory{mr_, canard_payload};
     EXPECT_THAT(canard_memory.size(), payload_size);
+    EXPECT_THAT(canard_payload.size, 0);
+    EXPECT_THAT(canard_payload.data, nullptr);
+    EXPECT_THAT(canard_payload.allocated_size, 0);
 
     // Ask exactly as payload
     {
@@ -169,8 +173,12 @@ TEST_F(TestCanDelegate, CanardMemory_copy_on_moved)
         static_cast<byte*>(canard_instance.memory.allocate(static_cast<TransportDelegate*>(&delegate), payload_size));
     fillIotaBytes({payload, payload_size}, b('0'));
 
-    CanardMemory old_canard_memory{mr_, payload_size, payload, payload_size};
+    CanardMutablePayload canard_payload{payload_size, payload, payload_size};
+    CanardMemory old_canard_memory{mr_, canard_payload};
     EXPECT_THAT(old_canard_memory.size(), payload_size);
+    EXPECT_THAT(canard_payload.size, 0);
+    EXPECT_THAT(canard_payload.data, nullptr);
+    EXPECT_THAT(canard_payload.allocated_size, 0);
 
     const CanardMemory new_canard_memory{std::move(old_canard_memory)};
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move,bugprone-use-after-move,hicpp-invalid-access-moved)

--- a/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
+++ b/test/unittest/transport/can/test_can_svc_rx_sessions.cpp
@@ -474,7 +474,7 @@ TEST_F(TestCanSvcRxSessions, receive_response)
                 EXPECT_THAT(now(), rx_timestamp);
                 EXPECT_THAT(p.size(), CANARD_MTU_MAX);
                 p[0] = b(0b111'11101);
-                return IMedia::PopResult::Metadata{rx_timestamp, 0b011'1'0'0'101111011'0010011'0110001, 1};
+                return IMedia::PopResult::Metadata{rx_timestamp, 0b011'1'0'0'101111011'0010011'0110011, 1};
             });
         scheduler_.scheduleNamedCallback("rx", rx_timestamp);
 

--- a/test/unittest/transport/can/test_can_transport.cpp
+++ b/test/unittest/transport/can/test_can_transport.cpp
@@ -468,6 +468,10 @@ TEST_F(TestCanTransport, makeResponseRxSession_invalid_resubscription)
 
         EXPECT_CALL(media_mock_, setFilters(IsEmpty()))  //
             .WillOnce([&](Filters) { return cetl::nullopt; });
+
+        // Different remote node id 0x32!
+        auto maybe_rx_session3 = transport->makeResponseRxSession({0, test_subject_id, 0x32});
+        ASSERT_THAT(maybe_rx_session3, VariantWith<UniquePtr<IResponseRxSession>>(NotNull()));
     });
     scheduler_.spinFor(10s);
 }

--- a/test/unittest/transport/test_session_tree.cpp
+++ b/test/unittest/transport/test_session_tree.cpp
@@ -7,9 +7,10 @@
 #include "tracking_memory_resource.hpp"
 
 #include <cetl/pf17/cetlpf.hpp>
+#include <libcyphal/common/cavl/cavl.hpp>
 #include <libcyphal/errors.hpp>
 #include <libcyphal/transport/errors.hpp>
-#include <libcyphal/transport/udp/session_tree.hpp>
+#include <libcyphal/transport/session_tree.hpp>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -24,8 +25,7 @@ namespace
 {
 
 using libcyphal::MemoryError;
-using namespace libcyphal::transport;       // NOLINT This our main concern here in the unit tests.
-using namespace libcyphal::transport::udp;  // NOLINT This our main concern here in the unit tests.
+using namespace libcyphal::transport;  // NOLINT This our main concern here in the unit tests.
 
 using testing::_;
 using testing::StrEq;
@@ -42,10 +42,11 @@ using testing::VariantWith;
 class TestSessionTree : public testing::Test
 {
 protected:
-    class MyNode final : public detail::RxSessionTreeNode::Base<MyNode>
+    class MyNode final : public libcyphal::common::cavl::Node<MyNode>
     {
     public:
-        using Params = std::int32_t;
+        using Params           = std::int32_t;
+        using ReferenceWrapper = std::reference_wrapper<MyNode>;
 
         explicit MyNode(const Params& params, const std::tuple<const char*>& args_tuple)
             : params_{params}

--- a/test/unittest/transport/udp/test_session_tree.cpp
+++ b/test/unittest/transport/udp/test_session_tree.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <tuple>
 #include <utility>
 
 namespace
@@ -46,9 +47,9 @@ protected:
     public:
         using Params = std::int32_t;
 
-        explicit MyNode(const Params& params, const char* const extra_arg)
+        explicit MyNode(const Params& params, const std::tuple<const char*>& args_tuple)
             : params_{params}
-            , extra_arg_{extra_arg}
+            , extra_arg_{std::get<0>(args_tuple)}
         {
         }
 

--- a/test/unittest/transport/udp/test_session_tree.cpp
+++ b/test/unittest/transport/udp/test_session_tree.cpp
@@ -14,6 +14,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <utility>
@@ -28,6 +29,7 @@ using namespace libcyphal::transport::udp;  // NOLINT This our main concern here
 using testing::_;
 using testing::Return;
 using testing::IsEmpty;
+using testing::Pointer;
 using testing::StrictMock;
 using testing::VariantWith;
 
@@ -39,7 +41,13 @@ protected:
     class MyNode final : public detail::RxSessionTreeNode::Base<MyNode>
     {
     public:
-        using Base::Base;
+        using Params = std::int32_t;
+
+        explicit MyNode(const Params& params)
+            : params_{params}
+            , extra_arg_{0}
+        {
+        }
 
         MyNode(const MyNode&)                = delete;
         MyNode(MyNode&&) noexcept            = delete;
@@ -54,14 +62,22 @@ protected:
             }
         }
 
+        CETL_NODISCARD std::int32_t compareByParams(const Params& params) const
+        {
+            return params_ - params;
+        }
+
         void setNotifier(std::function<void(const std::string&)> notifier)
         {
             notifier_ = std::move(notifier);
         }
 
     private:
+        const Params                            params_;
+        const int                               extra_arg_;
         std::function<void(const std::string&)> notifier_;
-    };
+
+    };  // MyNode
 
     void SetUp() override
     {
@@ -90,22 +106,46 @@ TEST_F(TestSessionTree, constructor_destructor_empty_tree)
     EXPECT_THAT(tree.isEmpty(), true);
 }
 
-TEST_F(TestSessionTree, ensureNewNodeFor)
+TEST_F(TestSessionTree, ensureNodeFor_should_be_new)
 {
     detail::SessionTree<MyNode> tree{mr_};
 
-    EXPECT_THAT(tree.ensureNewNodeFor(0), VariantWith<MyNode::ReferenceWrapper>(_));
+    EXPECT_THAT(tree.ensureNodeFor<true>(0), VariantWith<MyNode::ReferenceWrapper>(_));
     EXPECT_THAT(tree.isEmpty(), false);
 
-    EXPECT_THAT(tree.ensureNewNodeFor(1), VariantWith<MyNode::ReferenceWrapper>(_));
-    EXPECT_THAT(tree.ensureNewNodeFor(2), VariantWith<MyNode::ReferenceWrapper>(_));
-
-    EXPECT_THAT(tree.ensureNewNodeFor(0), VariantWith<AnyFailure>(VariantWith<AlreadyExistsError>(_)));
-    EXPECT_THAT(tree.ensureNewNodeFor(1), VariantWith<AnyFailure>(VariantWith<AlreadyExistsError>(_)));
-    EXPECT_THAT(tree.ensureNewNodeFor(2), VariantWith<AnyFailure>(VariantWith<AlreadyExistsError>(_)));
+    EXPECT_THAT(tree.ensureNodeFor<true>(1), VariantWith<MyNode::ReferenceWrapper>(_));
+    EXPECT_THAT(tree.ensureNodeFor<true>(2), VariantWith<MyNode::ReferenceWrapper>(_));
+    EXPECT_THAT(tree.ensureNodeFor<true>(0), VariantWith<AnyFailure>(VariantWith<AlreadyExistsError>(_)));
+    EXPECT_THAT(tree.ensureNodeFor<true>(1), VariantWith<AnyFailure>(VariantWith<AlreadyExistsError>(_)));
+    EXPECT_THAT(tree.ensureNodeFor<true>(2), VariantWith<AnyFailure>(VariantWith<AlreadyExistsError>(_)));
 }
 
-TEST_F(TestSessionTree, ensureNewNodeFor_no_memory)
+TEST_F(TestSessionTree, ensureNodeFor_existing_is_fine)
+{
+    detail::SessionTree<MyNode> tree{mr_};
+
+    auto maybe_node_0a = tree.ensureNodeFor(0);
+    ASSERT_THAT(maybe_node_0a, VariantWith<MyNode::ReferenceWrapper>(_));
+    const auto node_0a = cetl::get<MyNode::ReferenceWrapper>(maybe_node_0a);
+
+    EXPECT_THAT(tree.isEmpty(), false);
+
+    auto maybe_node_1a = tree.ensureNodeFor(1);
+    EXPECT_THAT(maybe_node_1a, VariantWith<MyNode::ReferenceWrapper>(_));
+    const auto node_1a = cetl::get<MyNode::ReferenceWrapper>(maybe_node_1a);
+
+    EXPECT_THAT(tree.ensureNodeFor(2), VariantWith<MyNode::ReferenceWrapper>(_));
+
+    auto maybe_node_0b = tree.ensureNodeFor(0);
+    EXPECT_THAT(maybe_node_0b, VariantWith<MyNode::ReferenceWrapper>(Pointer(&node_0a.get())));
+
+    auto maybe_node_1b = tree.ensureNodeFor(1);
+    EXPECT_THAT(maybe_node_1b, VariantWith<MyNode::ReferenceWrapper>(Pointer(&node_1a.get())));
+
+    EXPECT_THAT(tree.ensureNodeFor(2), VariantWith<MyNode::ReferenceWrapper>(_));
+}
+
+TEST_F(TestSessionTree, ensureNodeFor_no_memory)
 {
     StrictMock<MemoryResourceMock> mr_mock;
     mr_mock.redirectExpectedCallsTo(mr_);
@@ -116,7 +156,7 @@ TEST_F(TestSessionTree, ensureNewNodeFor_no_memory)
     EXPECT_CALL(mr_mock, do_allocate(sizeof(MyNode), _))  //
         .WillOnce(Return(nullptr));
 
-    EXPECT_THAT(tree.ensureNewNodeFor(0), VariantWith<AnyFailure>(VariantWith<MemoryError>(_)));
+    EXPECT_THAT(tree.ensureNodeFor(0), VariantWith<AnyFailure>(VariantWith<MemoryError>(_)));
 }
 
 TEST_F(TestSessionTree, removeNodeFor)
@@ -125,7 +165,7 @@ TEST_F(TestSessionTree, removeNodeFor)
 
     tree.removeNodeFor(13);
 
-    auto maybe_node = tree.ensureNewNodeFor(42);
+    auto maybe_node = tree.ensureNodeFor<true>(42);
     ASSERT_THAT(maybe_node, VariantWith<MyNode::ReferenceWrapper>(_));
     EXPECT_THAT(tree.isEmpty(), false);
 

--- a/test/unittest/transport/udp/test_udp_delegate.cpp
+++ b/test/unittest/transport/udp/test_udp_delegate.cpp
@@ -10,6 +10,7 @@
 #include <cetl/pf17/cetlpf.hpp>
 #include <libcyphal/errors.hpp>
 #include <libcyphal/transport/errors.hpp>
+#include <libcyphal/transport/svc_sessions.hpp>
 #include <libcyphal/transport/types.hpp>
 #include <libcyphal/transport/udp/delegate.hpp>
 #include <libcyphal/types.hpp>
@@ -81,6 +82,11 @@ protected:
 
         MOCK_METHOD(void, onSessionEvent, (const SessionEvent::Variant& event_var), (override));
 
+        MOCK_METHOD(udp::detail::IRxSessionDelegate*,
+                    tryFindRxSessionDelegateFor,
+                    (const ResponseRxParams& params),
+                    (override));
+
     };  // TransportDelegateImpl
 
     void SetUp() override
@@ -108,7 +114,7 @@ protected:
     UdpardFragment* allocateNewUdpardFragment(const std::size_t size)
     {
         // This structure mimics internal Udpard `RxFragment` layout.
-        // We need this to know its size, so that test tear down can check if all memory was deallocated.
+        // We need this to know its size, so that test teardown can check if all memory was deallocated.
         // @see `EXPECT_THAT(fragment_mr_.total_allocated_bytes, fragment_mr_.total_deallocated_bytes);`
         //
         struct RxFragment
@@ -158,7 +164,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy)
 
     // Ask exactly as payload
     {
-        const std::size_t          ask_size = payload_size;
+        constexpr std::size_t      ask_size = payload_size;
         std::array<byte, ask_size> buffer{};
 
         EXPECT_THAT(udpard_memory.copy(0, buffer.data(), ask_size), ask_size);
@@ -167,7 +173,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy)
 
     // Ask more than payload
     {
-        const std::size_t          ask_size = payload_size + 2;
+        constexpr std::size_t      ask_size = payload_size + 2;
         std::array<byte, ask_size> buffer{};
 
         EXPECT_THAT(udpard_memory.copy(0, buffer.data(), ask_size), payload_size);
@@ -176,7 +182,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy)
 
     // Ask less than payload (with different offsets)
     {
-        const std::size_t          ask_size = payload_size - 2;
+        constexpr std::size_t      ask_size = payload_size - 2;
         std::array<byte, ask_size> buffer{};
 
         EXPECT_THAT(udpard_memory.copy(0, buffer.data(), ask_size), ask_size);
@@ -230,7 +236,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy_on_moved)
         EXPECT_THAT(buffer, Each(b('\0')));
     }
 
-    // Try new one
+    // Try a new one
     {
         std::array<byte, payload_size> buffer{};
         EXPECT_THAT(new_udpard_memory.copy(0, buffer.data(), buffer.size()), payload_size);
@@ -257,7 +263,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy_multi_fragmented)
     fillIotaBytes({payload1, 8}, b('A'));
     fillIotaBytes({payload2, 9}, b('a'));
 
-    const std::size_t payload_size       = 3 + 4 + 2;
+    constexpr std::size_t payload_size   = 3 + 4 + 2;
     rx_transfer.payload_size             = payload_size;
     rx_transfer.payload.view             = {3, payload0 + 2};
     rx_transfer.payload.next->view       = {4, payload1 + 1};
@@ -268,7 +274,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy_multi_fragmented)
 
     // Ask exactly as payload
     {
-        const std::size_t          ask_size = payload_size;
+        constexpr std::size_t      ask_size = payload_size;
         std::array<byte, ask_size> buffer{};
 
         EXPECT_THAT(udpard_memory.copy(0, buffer.data(), ask_size), ask_size);
@@ -277,7 +283,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy_multi_fragmented)
 
     // Ask more than payload
     {
-        const std::size_t          ask_size = payload_size + 2;
+        constexpr std::size_t      ask_size = payload_size + 2;
         std::array<byte, ask_size> buffer{};
 
         EXPECT_THAT(udpard_memory.copy(0, buffer.data(), ask_size), payload_size);
@@ -287,7 +293,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy_multi_fragmented)
 
     // Ask less than payload (with different offsets)
     {
-        const std::size_t          ask_size = payload_size - 2;
+        constexpr std::size_t      ask_size = payload_size - 2;
         std::array<byte, ask_size> buffer{};
 
         EXPECT_THAT(udpard_memory.copy(0, buffer.data(), ask_size), ask_size);

--- a/test/unittest/transport/udp/test_udp_delegate.cpp
+++ b/test/unittest/transport/udp/test_udp_delegate.cpp
@@ -54,7 +54,9 @@ using testing::VariantWith;
 class TestUdpDelegate : public testing::Test
 {
 protected:
-    class TransportDelegateImpl final : public detail::TransportDelegate
+    using TransportDelegate = udp::detail::TransportDelegate;
+
+    class TransportDelegateImpl final : public TransportDelegate
     {
     public:
         using TransportDelegate::MemoryResources;
@@ -80,7 +82,7 @@ protected:
                      const PayloadFragments                           payload_fragments),
                     (override));
 
-        MOCK_METHOD(void, onSessionEvent, (const SessionEvent::Variant& event_var), (override));
+        MOCK_METHOD(void, onSessionEvent, (const SessionEvent::Variant& event_var), (noexcept, override));
 
         MOCK_METHOD(udp::detail::IRxSessionDelegate*,
                     tryFindRxSessionDelegateFor,
@@ -147,7 +149,7 @@ protected:
 
 TEST_F(TestUdpDelegate, UdpardMemory_copy)
 {
-    using UdpardMemory = udp::detail::TransportDelegate::UdpardMemory;
+    using UdpardMemory = TransportDelegate::UdpardMemory;
 
     TransportDelegateImpl delegate{general_mr_, &fragment_mr_, &payload_mr_};
 
@@ -208,7 +210,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy)
 
 TEST_F(TestUdpDelegate, UdpardMemory_copy_on_moved)
 {
-    using UdpardMemory = udp::detail::TransportDelegate::UdpardMemory;
+    using UdpardMemory = TransportDelegate::UdpardMemory;
 
     TransportDelegateImpl delegate{general_mr_, &fragment_mr_, &payload_mr_};
 
@@ -246,7 +248,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy_on_moved)
 
 TEST_F(TestUdpDelegate, UdpardMemory_copy_multi_fragmented)
 {
-    using UdpardMemory = udp::detail::TransportDelegate::UdpardMemory;
+    using UdpardMemory = TransportDelegate::UdpardMemory;
 
     TransportDelegateImpl delegate{general_mr_, &fragment_mr_, &payload_mr_};
 
@@ -322,7 +324,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy_multi_fragmented)
 
 TEST_F(TestUdpDelegate, UdpardMemory_copy_empty)
 {
-    using UdpardMemory = udp::detail::TransportDelegate::UdpardMemory;
+    using UdpardMemory = TransportDelegate::UdpardMemory;
 
     TransportDelegateImpl delegate{general_mr_, &fragment_mr_, &payload_mr_};
 
@@ -341,21 +343,21 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy_empty)
 
 TEST_F(TestUdpDelegate, optAnyFailureFromUdpard)
 {
-    EXPECT_THAT(udp::detail::TransportDelegate::optAnyFailureFromUdpard(-UDPARD_ERROR_MEMORY),
+    EXPECT_THAT(TransportDelegate::optAnyFailureFromUdpard(-UDPARD_ERROR_MEMORY),
                 Optional(VariantWith<MemoryError>(_)));
 
-    EXPECT_THAT(udp::detail::TransportDelegate::optAnyFailureFromUdpard(-UDPARD_ERROR_ARGUMENT),
+    EXPECT_THAT(TransportDelegate::optAnyFailureFromUdpard(-UDPARD_ERROR_ARGUMENT),
                 Optional(VariantWith<libcyphal::ArgumentError>(_)));
 
-    EXPECT_THAT(udp::detail::TransportDelegate::optAnyFailureFromUdpard(-UDPARD_ERROR_CAPACITY),
+    EXPECT_THAT(TransportDelegate::optAnyFailureFromUdpard(-UDPARD_ERROR_CAPACITY),
                 Optional(VariantWith<CapacityError>(_)));
 
-    EXPECT_THAT(udp::detail::TransportDelegate::optAnyFailureFromUdpard(-UDPARD_ERROR_ANONYMOUS),
+    EXPECT_THAT(TransportDelegate::optAnyFailureFromUdpard(-UDPARD_ERROR_ANONYMOUS),
                 Optional(VariantWith<AnonymousError>(_)));
 
-    EXPECT_THAT(udp::detail::TransportDelegate::optAnyFailureFromUdpard(0), Eq(cetl::nullopt));
-    EXPECT_THAT(udp::detail::TransportDelegate::optAnyFailureFromUdpard(1), Eq(cetl::nullopt));
-    EXPECT_THAT(udp::detail::TransportDelegate::optAnyFailureFromUdpard(-1), Eq(cetl::nullopt));
+    EXPECT_THAT(TransportDelegate::optAnyFailureFromUdpard(0), Eq(cetl::nullopt));
+    EXPECT_THAT(TransportDelegate::optAnyFailureFromUdpard(1), Eq(cetl::nullopt));
+    EXPECT_THAT(TransportDelegate::optAnyFailureFromUdpard(-1), Eq(cetl::nullopt));
 }
 
 TEST_F(TestUdpDelegate, makeUdpardMemoryResource)

--- a/test/unittest/transport/udp/test_udp_delegate.cpp
+++ b/test/unittest/transport/udp/test_udp_delegate.cpp
@@ -83,7 +83,7 @@ protected:
                      const PayloadFragments                           payload_fragments),
                     (override));
 
-        MOCK_METHOD(void, onSessionEvent, (const SessionEvent::Variant& event_var), (noexcept, override));
+        MOCK_METHOD(void, onSessionEvent, (const SessionEvent::Variant& event_var), (noexcept, override));  // NOLINT
 
         MOCK_METHOD(udp::detail::IRxSessionDelegate*,
                     tryFindRxSessionDelegateFor,
@@ -150,7 +150,7 @@ protected:
 
 TEST_F(TestUdpDelegate, UdpardMemory_copy)
 {
-    TransportDelegateImpl delegate{general_mr_, &fragment_mr_, &payload_mr_};
+    const TransportDelegateImpl delegate{general_mr_, &fragment_mr_, &payload_mr_};
 
     auto* const payload = allocateNewUdpardPayload(4);
     fillIotaBytes({payload, 4}, b('0'));
@@ -162,6 +162,12 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy)
 
     const UdpardMemory udpard_memory{delegate.memoryResources(), rx_transfer};
     EXPECT_THAT(udpard_memory.size(), payload_size);
+    EXPECT_THAT(rx_transfer.payload_size, 0);
+    EXPECT_THAT(rx_transfer.payload.next, nullptr);
+    EXPECT_THAT(rx_transfer.payload.view.size, 0);
+    EXPECT_THAT(rx_transfer.payload.view.data, nullptr);
+    EXPECT_THAT(rx_transfer.payload.origin.size, 0);
+    EXPECT_THAT(rx_transfer.payload.origin.data, nullptr);
 
     // Ask exactly as payload
     {
@@ -209,7 +215,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy)
 
 TEST_F(TestUdpDelegate, UdpardMemory_copy_on_moved)
 {
-    TransportDelegateImpl delegate{general_mr_, &fragment_mr_, &payload_mr_};
+    const TransportDelegateImpl delegate{general_mr_, &fragment_mr_, &payload_mr_};
 
     constexpr std::size_t payload_size = 4;
     auto* const           payload      = allocateNewUdpardPayload(payload_size);
@@ -245,7 +251,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy_on_moved)
 
 TEST_F(TestUdpDelegate, UdpardMemory_copy_multi_fragmented)
 {
-    TransportDelegateImpl delegate{general_mr_, &fragment_mr_, &payload_mr_};
+    const TransportDelegateImpl delegate{general_mr_, &fragment_mr_, &payload_mr_};
 
     auto* const payload0 = allocateNewUdpardPayload(7);
 
@@ -319,7 +325,7 @@ TEST_F(TestUdpDelegate, UdpardMemory_copy_multi_fragmented)
 
 TEST_F(TestUdpDelegate, UdpardMemory_copy_empty)
 {
-    TransportDelegateImpl delegate{general_mr_, &fragment_mr_, &payload_mr_};
+    const TransportDelegateImpl delegate{general_mr_, &fragment_mr_, &payload_mr_};
 
     UdpardRxTransfer rx_transfer{};
     rx_transfer.payload_size = 0;

--- a/test/unittest/transport/udp/test_udp_svc_rx_sessions.cpp
+++ b/test/unittest/transport/udp/test_udp_svc_rx_sessions.cpp
@@ -173,9 +173,9 @@ TEST_F(TestUdpSvcRxSessions, make_response_no_memory)
     EXPECT_CALL(mr_mock, do_allocate(sizeof(udp::detail::SvcResponseRxSession), _))  //
         .WillOnce(Return(nullptr));
 
-    auto transport = makeTransport({mr_mock});
+    const auto transport = makeTransport({mr_mock});
 
-    auto maybe_session = transport->makeResponseRxSession({64, 0x23, 0x45});
+    const auto maybe_session = transport->makeResponseRxSession({64, 0x23, 0x45});
     EXPECT_THAT(maybe_session, VariantWith<AnyFailure>(VariantWith<MemoryError>(_)));
 }
 
@@ -214,12 +214,27 @@ TEST_F(TestUdpSvcRxSessions, make_response_fails_due_to_rx_socket_error)
     }
 }
 
+TEST_F(TestUdpSvcRxSessions, make_request_no_memory)
+{
+    StrictMock<MemoryResourceMock> mr_mock;
+    mr_mock.redirectExpectedCallsTo(mr_);
+
+    // Emulate that there is no memory available for the message session.
+    EXPECT_CALL(mr_mock, do_allocate(sizeof(udp::detail::SvcRequestRxSession), _))  //
+        .WillOnce(Return(nullptr));
+
+    const auto transport = makeTransport({mr_mock});
+
+    const auto maybe_session = transport->makeRequestRxSession({64, 0x7B});
+    EXPECT_THAT(maybe_session, VariantWith<AnyFailure>(VariantWith<MemoryError>(_)));
+}
+
 TEST_F(TestUdpSvcRxSessions, make_request_fails_due_to_argument_error)
 {
-    auto transport = makeTransport({mr_});
+    const auto transport = makeTransport({mr_});
 
     // Try invalid subject id
-    auto maybe_session = transport->makeRequestRxSession({64, UDPARD_SERVICE_ID_MAX + 1});
+    const auto maybe_session = transport->makeRequestRxSession({64, UDPARD_SERVICE_ID_MAX + 1});
     EXPECT_THAT(maybe_session, VariantWith<AnyFailure>(VariantWith<libcyphal::ArgumentError>(_)));
 }
 

--- a/test/unittest/transport/udp/test_udp_svc_rx_sessions.cpp
+++ b/test/unittest/transport/udp/test_udp_svc_rx_sessions.cpp
@@ -601,7 +601,7 @@ TEST_F(TestUdpSvcRxSessions, receive_response)
         //
         SCOPED_TRACE("3-rd iteration: unsolicited (node 0x33) response @ 3s");
 
-        constexpr std::size_t payload_size = 0;
+        constexpr std::size_t payload_size = 2;
         constexpr std::size_t frame_size   = UdpardFrame::SizeOfHeaderAndTxCrc + payload_size;
 
         rx_timestamp = now() + 10ms;
@@ -609,6 +609,8 @@ TEST_F(TestUdpSvcRxSessions, receive_response)
             .WillOnce([&]() -> IRxSocket::ReceiveResult::Metadata {
                 EXPECT_THAT(now(), rx_timestamp);
                 auto frame         = UdpardFrame(0x33, 0x13, 0x1D, payload_size, &payload_mr_mock, Priority::High);
+                frame.payload()[0] = b(42);
+                frame.payload()[1] = b(147);
                 frame.setPortId(0x17B, true /*is_service*/, false /*is_request*/);
                 std::uint32_t tx_crc = UdpardFrame::InitialTxCrc;
                 return {rx_timestamp, std::move(frame).release(tx_crc)};

--- a/test/unittest/transport/udp/test_udp_transport.cpp
+++ b/test/unittest/transport/udp/test_udp_transport.cpp
@@ -458,6 +458,10 @@ TEST_F(TestUpdTransport, makeResponseRxSession_invalid_resubscription)
         //
         auto maybe_rx_session2 = transport->makeResponseRxSession({0, test_subject_id, 0x31});
         ASSERT_THAT(maybe_rx_session2, VariantWith<UniquePtr<IResponseRxSession>>(NotNull()));
+
+        // Different remote node id 0x32!
+        auto maybe_rx_session3 = transport->makeResponseRxSession({0, test_subject_id, 0x32});
+        ASSERT_THAT(maybe_rx_session3, VariantWith<UniquePtr<IResponseRxSession>>(NotNull()));
     });
     scheduler_.scheduleAt(9s, [&](const auto&) {
         //


### PR DESCRIPTION
1. Response Rx Session now doesn't own lizard's rpc port subscription - instead now session references the shared subscription (with reference counting).
2. Transport delegates now manage subscriptions.
3. CAN Response Rx Sessions now stored in cavl tree (for UDP it was already like this) - matching now by both port and node ids (previously it was by the port only).
4. CAN filters now also are made by the delegate (b/c it knows about subscriptions (see bullet # 2).
5. Extended unit tests to cover multiple response Rx sessions (both CAN and UDP). Also covered unsolicited responses.

Github's Hide whitespaces is recommended.