### PR TITLE
Boost Code Comprehension with an AI-Generated ProductMap for can_transport_impl.hpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@
 Portable reference implementation of the [Cyphal protocol stack](https://opencyphal.org) in C++ for embedded systems, Linux, and POSIX-compliant RTOSs.
 
 Cyphal is a lightweight protocol designed for reliable communication in aerospace and robotic applications over robust vehicular networks.
+## AI-generated ProductMaps
+
+
+
+| Github file | ProductMap |
+|-------------|------------|
+| [can_transport_impl.hpp](https://github.com/OpenCyphal-Garage/libcyphal/blob/main/include/libcyphal/transport/can/can_transport_impl.hpp) | [Link to Map](https://product-map.ai/app/public?url=https://github.com/OpenCyphal-Garage/libcyphal/blob/main/include/libcyphal/transport/can/can_transport_impl.hpp) |
+
+Contact ProductMap if you have any questions at [juan@product-map.ai](juan@product-map.ai).
+
+Last updated on Mon Feb 03 22:58:06 UTC 2025.


### PR DESCRIPTION
This PR introduces an AI-generated [ProductMap](https://product-map.ai/app/public?url=https://github.com/OpenCyphal-Garage/libcyphal/blob/main/include/libcyphal/transport/can/can_transport_impl.hpp) for [can_transport_impl.hpp](https://github.com/OpenCyphal-Garage/libcyphal/blob/main/include/libcyphal/transport/can/can_transport_impl.hpp), providing an interactive visual representation of the code’s functionality. Zoom in and out to explore different abstraction levels and gain instant insights.
🚀 Why This Matters:
- Helps developers quickly understand complex code without manual documentation.
- Bridges the gap between code structure and functionality, improving team alignment.
- Saves time on onboarding, debugging, and refactoring.
I’d love your feedback—does this format help you navigate the code more effectively?
🔗 Learn more about Product-Map.AI [here](https://product-map.ai).
📩 Reach me at juan@product-map.ai for free AI-generated maps—for more files or seamless updates via CI/CD integration. 🚀