### PR TITLE
Fixed CAN transport media TX callback lifetime.

### DIFF
--- a/include/libcyphal/transport/can/can_transport_impl.hpp
+++ b/include/libcyphal/transport/can/can_transport_impl.hpp
@@ -683,6 +683,14 @@ private:
                     return (*frame_handler_ptr)(deadline, *frame);
                 });
         }
+
+        if ((result == 0) && (media.canard_tx_queue().size == 0))
+        {
+            // There was nothing successfully polled,
+            // AND won't be in the (near) future (b/c queue is empty),
+            // so we are done with this TX media - no more callbacks for now (until brand new TX transfer).
+            media.tx_callback().reset();
+        }
     }
 
     /// @brief Tries to peek the first TX item from the media TX queue which is not expired.

--- a/include/libcyphal/transport/udp/udp_transport_impl.hpp
+++ b/include/libcyphal/transport/udp/udp_transport_impl.hpp
@@ -760,7 +760,9 @@ private:
 
         }  // for a valid tx item
 
-        // There is nothing to send anymore, so we are done with this media TX socket - no more callbacks for now.
+        // There was nothing successfully sent (otherwise we would have `return`-ed earlier),
+        // AND won't be in the (near) future (b/c queue is empty),
+        // so we are done with this TX media - no more callbacks for now (until brand new TX transfer).
         media.txSocketState().callback.reset();
     }
 

--- a/test/unittest/transport/udp/test_udp_transport.cpp
+++ b/test/unittest/transport/udp/test_udp_transport.cpp
@@ -610,7 +610,7 @@ TEST_F(TestUpdTransport, sending_multiframe_payload_for_non_anonymous)
     });
     scheduler_.scheduleAt(1s + 20us, [&](const auto&) {
         //
-        // Callback still there b/c the 2nd frame was sent.
+        // Callback is still there b/c the 2nd frame was sent.
         ASSERT_TRUE(scheduler_.hasNamedCallback("tx"));
 
         // Emulate that media done with the 2nd frame - this should remove the callback b/c TX queue is empty.


### PR DESCRIPTION
Fix for issue #438:
- Fixed callback lifetime bug in CAN transport; added unit test to specifically verify TX media callback lifetime.
- Although there is no such issue at UDP transport, still added similar test for udp as well.